### PR TITLE
fix: avoid the caption span line breaking

### DIFF
--- a/src/pages/grupo/[summary].tsx
+++ b/src/pages/grupo/[summary].tsx
@@ -709,6 +709,7 @@ const CaptionItems = styled.li`
     margin-top: 1rem;
     font-size: 1.5rem;
     color: #3e5363;
+    white-space: nowrap;
     & > * {
       font-size: 1.5rem;
     }


### PR DESCRIPTION
Esse PR
* corrige a quebra de linha na exibição de valores nas legendas da tela de dados