### PR TITLE
integrate-lgpd-with-cookie-politics

### DIFF
--- a/src/components/GATracker.tsx
+++ b/src/components/GATracker.tsx
@@ -1,12 +1,15 @@
 import React, { useEffect } from 'react';
 import ReactGA from 'react-ga';
-
+import { usePrivacityPolicy } from '../contexts/privacity-policy-context';
 // this component is a wrapper used to inject the google analytics in all children components, it connects with google analytics using the React-GA LIB https://github.com/react-ga/react-ga
 const GATracker: React.FC = ({ children }) => {
+  const { accepted } = usePrivacityPolicy();
   useEffect(() => {
-    ReactGA.initialize(process.env.ID_ANALYTICS);
-    ReactGA.pageview(window.location.pathname);
-  });
+    if (accepted) {
+      ReactGA.initialize(process.env.ID_ANALYTICS);
+      ReactGA.pageview(window.location.pathname);
+    }
+  }, [accepted]);
   return <>{children}</>;
 };
 

--- a/src/components/GATracker.tsx
+++ b/src/components/GATracker.tsx
@@ -5,6 +5,7 @@ import { usePrivacityPolicy } from '../contexts/privacity-policy-context';
 const GATracker: React.FC = ({ children }) => {
   const { accepted } = usePrivacityPolicy();
   useEffect(() => {
+    // here we avoid the Google Analitycs until the user accept the privacity policy.
     if (accepted) {
       ReactGA.initialize(process.env.ID_ANALYTICS);
       ReactGA.pageview(window.location.pathname);

--- a/src/components/PrivacityPolicyPopUp.tsx
+++ b/src/components/PrivacityPolicyPopUp.tsx
@@ -12,6 +12,7 @@ const PrivacityPolicyPopUp: React.FC = () => {
         dentro do nosso sistema, ao aceitar os cookies você concorda com a nossa{' '}
         <Link href="/politica-de-privacidade">política de privacidade</Link>.
       </span>
+      {/* here we send the information to PrivacityPolicyContext to allow the cookie storing */}
       <button type="button" onClick={acceptCookies}>
         Aceitar Cookies
       </button>

--- a/src/components/PrivacityPolicyPopUp.tsx
+++ b/src/components/PrivacityPolicyPopUp.tsx
@@ -1,17 +1,23 @@
 import Link from 'next/link';
 import React from 'react';
 import styled from 'styled-components';
+import { usePrivacityPolicy } from '../contexts/privacity-policy-context';
 
-const PrivacityPolicePopUp: React.FC = () => (
-  <Container>
-    <span>
-      O DadosJusBr utiliza Cookies para melhorar a experiencia do usuário dentro
-      do nosso sistema, ao aceitar os cookies você concorda com a nossa{' '}
-      <Link href="/politica-de-privacidade">política de privacidade</Link>.
-    </span>
-    <button type="button">Aceitar Cookies</button>
-  </Container>
-);
+const PrivacityPolicyPopUp: React.FC = () => {
+  const { acceptCookies } = usePrivacityPolicy();
+  return (
+    <Container>
+      <span>
+        O DadosJusBr utiliza Cookies para melhorar a experiencia do usuário
+        dentro do nosso sistema, ao aceitar os cookies você concorda com a nossa{' '}
+        <Link href="/politica-de-privacidade">política de privacidade</Link>.
+      </span>
+      <button type="button" onClick={acceptCookies}>
+        Aceitar Cookies
+      </button>
+    </Container>
+  );
+};
 export const Container = styled.div`
   position: fixed;
   background-color: #3e5363;
@@ -56,4 +62,4 @@ export const Container = styled.div`
   }
 `;
 
-export default PrivacityPolicePopUp;
+export default PrivacityPolicyPopUp;

--- a/src/components/PrivacityPolicyPopUp.tsx
+++ b/src/components/PrivacityPolicyPopUp.tsx
@@ -28,7 +28,7 @@ export const Container = styled.div`
   padding: 2.5rem;
   color: #fff;
   font-size: 2rem;
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 -5px 20px rgba(0, 0, 0, 0.23);
   font-family: 'Roboto Condensed', sans-serif;
   margin-left: auto;
   margin-right: auto;
@@ -42,6 +42,8 @@ export const Container = styled.div`
   }
   @media (max-width: 600px) {
     bottom: 0;
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19),
+      0px -6px 6px rgba(0, 0, 0, 0.23);
     width: 100%;
   }
 

--- a/src/components/PrivacityPoliticsPopUp.tsx
+++ b/src/components/PrivacityPoliticsPopUp.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link';
+import React from 'react';
+import styled from 'styled-components';
+
+const PrivacityPolicePopUp: React.FC = () => (
+  <Container>
+    <span>
+      O DadosJusBr utiliza Cookies para melhorar a experiencia do usuário dentro
+      do nosso sistema, ao aceitar os cookies você concorda com a nossa{' '}
+      <Link href="/politica-de-privacidade">política de privacidade</Link>.
+    </span>
+    <button type="button">Aceitar Cookies</button>
+  </Container>
+);
+export const Container = styled.div`
+  position: fixed;
+  background-color: #3e5363;
+  bottom: 2rem;
+  width: 98%;
+  left: 0;
+  right: 0;
+  padding: 2.5rem;
+  color: #fff;
+  font-size: 2rem;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
+  font-family: 'Roboto Condensed', sans-serif;
+  margin-left: auto;
+  margin-right: auto;
+  span {
+    font-size: 1.5rem;
+    a {
+      font-size: 1.5rem;
+      color: #47abff;
+      text-decoration: underline;
+    }
+  }
+  @media (max-width: 600px) {
+    bottom: 0;
+    width: 100%;
+  }
+
+  button {
+    margin-top: 1rem;
+    font-family: 'Roboto Condensed', sans-serif;
+    font-weight: bold;
+    padding: 1rem;
+    border: 2px solid #3e5363;
+    width: 100%;
+    color: #3e5363;
+    transition: background 0.2s ease;
+    &:hover {
+      color: #fff;
+      border: 2px solid #fff;
+      background-color: #3e5363;
+    }
+  }
+`;
+
+export default PrivacityPolicePopUp;

--- a/src/contexts/privacity-policy-context.tsx
+++ b/src/contexts/privacity-policy-context.tsx
@@ -1,0 +1,53 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+} from 'react';
+import PrivacityPolicyPopUp from '../components/PrivacityPolicyPopUp';
+
+interface PrivacityPolicyData {
+  accepted: boolean;
+  acceptCookies: () => void;
+}
+
+const PrivacityPolicyContext = createContext<PrivacityPolicyData>(
+  {} as PrivacityPolicyData,
+);
+
+export const PrivacityPolicyProvider: React.FC = ({ children }) => {
+  const [accepted, setAccepted] = useState(false);
+  const [checked, setChecked] = useState(true);
+  useEffect(() => {
+    const areadChecked = localStorage.getItem('accepted_cookie_policy');
+    if (areadChecked) {
+      setChecked(true);
+      setAccepted(Boolean(areadChecked));
+    } else {
+      setChecked(false);
+    }
+  }, [accepted]);
+  const acceptCookies = useCallback(() => {
+    localStorage.setItem('accepted_cookie_policy', 'true');
+    setAccepted(true);
+    setChecked(true);
+  }, [accepted, checked]);
+  return (
+    <PrivacityPolicyContext.Provider value={{ accepted, acceptCookies }}>
+      {children}
+      {!checked && <PrivacityPolicyPopUp />}
+    </PrivacityPolicyContext.Provider>
+  );
+};
+export function usePrivacityPolicy(): PrivacityPolicyData {
+  const context = useContext(PrivacityPolicyContext);
+
+  if (!context) {
+    throw new Error(
+      'usePrivacityPolicy must be used within a privacity policy provider',
+    );
+  }
+
+  return context;
+}

--- a/src/contexts/privacity-policy-context.tsx
+++ b/src/contexts/privacity-policy-context.tsx
@@ -15,7 +15,7 @@ interface PrivacityPolicyData {
 const PrivacityPolicyContext = createContext<PrivacityPolicyData>(
   {} as PrivacityPolicyData,
 );
-
+// this context is used to inject the privacity policy checking in all aplication, this structure uses the react use context pattern https://pt-br.reactjs.org/docs/context.html
 export const PrivacityPolicyProvider: React.FC = ({ children }) => {
   const [accepted, setAccepted] = useState(false);
   const [checked, setChecked] = useState(true);
@@ -40,6 +40,8 @@ export const PrivacityPolicyProvider: React.FC = ({ children }) => {
     </PrivacityPolicyContext.Provider>
   );
 };
+
+// this custom hook is used to use the privacity policy props in child react components
 export function usePrivacityPolicy(): PrivacityPolicyData {
   const context = useContext(PrivacityPolicyContext);
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,6 @@
 import GATracker from '../components/GATracker';
 import GlobalStyle from '../styles/global_style';
-
+import { PrivacityPolicyProvider } from '../contexts/privacity-policy-context';
 /*
 o _app.tsx nesse caso está sendo utilizado para conseguirmos
 usar a api de contextos do next, ela permite compartilharmos funcionalidades
@@ -10,10 +10,12 @@ https://nextjs.org/docs/advanced-features/custom-app
 function MyApp({ Component, pageProps }) {
   return (
     <>
-      <GATracker>
-        <Component {...pageProps} />
-        <GlobalStyle />
-      </GATracker>
+      <PrivacityPolicyProvider>
+        <GATracker>
+          <Component {...pageProps} />
+          <GlobalStyle />
+        </GATracker>
+      </PrivacityPolicyProvider>
     </>
   );
 }

--- a/src/pages/politica-de-privacidade.tsx
+++ b/src/pages/politica-de-privacidade.tsx
@@ -124,7 +124,7 @@ export default function PrivacityPolicy() {
             características de acesso e navegação em nosso site.
           </p>
 
-          <h4>3. COM QUEM COMPARTILHAMOS SEUS DADOS?</h4>
+          <h4>3. COMPARTILHAMENTO DOS DADOS</h4>
 
           <p>
             De forma geral, o DadosJusBr não venderá, compartilhará, cederá ou

--- a/src/pages/politica-de-privacidade.tsx
+++ b/src/pages/politica-de-privacidade.tsx
@@ -63,33 +63,38 @@ export default function PrivacityPolicy() {
               </p>
 
               <p>
-                Esses dados são coletados por meio de cookies. Você pode ajustar
-                suas configurações de navegador para desabilitar os cookies ou
-                deletá-los. Caso estejam habilitados, nós (e os terceiros
-                previamente mencionados) emitiremos cookies quando você
-                interagir com o nosso site. Somente coletamos, via cookies,
-                dados essenciais para o funcionamento do nosso site e para as
-                métricas de acesso. Não compartilhamos esses dados com
+                Esses dados são coletados por meio de{' '}
+                <a href="https://www.techtudo.com.br/noticias/2018/10/o-que-sao-cookies-entenda-os-dados-que-os-sites-guardam-sobre-voce.ghtml">
+                  cookies
+                </a>
+                . Você pode ajustar suas configurações de navegador para
+                desabilitar os cookies ou deletá-los. Caso estejam habilitados,
+                nós (e os terceiros previamente mencionados) emitiremos cookies
+                quando você interagir com o nosso site. Somente coletamos, via
+                cookies, dados essenciais para o funcionamento do nosso site e
+                para as métricas de acesso. Não compartilhamos esses dados com
                 terceiros, além daqueles responsáveis pelos próprios cookies.
               </p>
 
               <p>
                 Não serão automaticamente coletados dados pessoais; informações
-                dessa natureza serão registradas em nossos bancos de dados apenas
-                quando um formulário for preenchido voluntariamente pelo
+                dessa natureza serão registradas em nossos bancos de dados
+                apenas quando um formulário for preenchido voluntariamente pelo
                 usuário.
               </p>
 
               <p>
                 Além disso, o site do DadosJusBr usa a ferramenta{' '}
-                <strong>Google Analytics</strong> que analisa suas interações e
-                como você usa o site. O Google Analytics é um serviço de web
-                analytics que identifica os seus padrões de navegação no nosso
-                site e gera relatórios sobre essas atividades, para que possamos
-                melhorar o site do DadosJusBr. Para fazer isso, são
-                coletados/compartilhados dados pessoais para contato, como você
-                usa o site e dados que o identificam. O tratamento desses dados
-                é regido pela{' '}
+                <a href="https://analytics.google.com/analytics/web/">
+                  Google Analytics
+                </a>{' '}
+                que analisa suas interações e como você usa o site. O Google
+                Analytics é um serviço de web analytics que identifica os seus
+                padrões de navegação no nosso site e gera relatórios sobre essas
+                atividades, para que possamos melhorar o site do DadosJusBr.
+                Para fazer isso, são coletados/compartilhados dados pessoais
+                para contato, como você usa o site e dados que o identificam. O
+                tratamento desses dados é regido pela{' '}
                 <a
                   href="https://policies.google.com/privacy"
                   target="_blank"
@@ -119,8 +124,8 @@ export default function PrivacityPolicy() {
 
           <p>
             O DadosjusBR utliza os dados para: (i) nos comunicar com as pessoas
-            interessadas; (ii) divulgar as nossas atividades; (iii) promover a associação
-            de interessados à entidade; e (iv) identificar as
+            interessadas; (ii) divulgar as nossas atividades; (iii) promover a
+            associação de interessados à entidade; e (iv) identificar as
             características de acesso e navegação em nosso site.
           </p>
 
@@ -141,11 +146,11 @@ export default function PrivacityPolicy() {
           <h4>4. TEMPO DE ARMAZENAMENTO DOS DADOS</h4>
 
           <p>
-            O DadosJusBr apenas manterá os seus dados armazenados pelo tempo necessário
-            para o cumprimento das finalidades para as quais foram coletados. A
-            fim de manter o histórico de solicitações recebidas, os dados
-            pessoais fornecidos serão anonimizados no prazo máximo de 3 meses
-            após a coleta dos dados.
+            O DadosJusBr apenas manterá os seus dados armazenados pelo tempo
+            necessário para o cumprimento das finalidades para as quais foram
+            coletados. A fim de manter o histórico de solicitações recebidas, os
+            dados pessoais fornecidos serão anonimizados no prazo máximo de 3
+            meses após a coleta dos dados.
           </p>
 
           <h4>5. SOLICITAR ACESSO E EXCLUSÃO DE DADOS</h4>

--- a/src/pages/politica-de-privacidade.tsx
+++ b/src/pages/politica-de-privacidade.tsx
@@ -115,7 +115,7 @@ export default function PrivacityPolicy() {
             conforme indicado no Item 5 abaixo.
           </p>
 
-          <h4>2. COMO UTILIZAMOS OS DADOS COLETADOS?</h4>
+          <h4>2. FORMA DE UTILIZAÇÃO DOS DADOS COLETADOS</h4>
 
           <p>
             Os dados coletados serão apenas utilizados para as finalidades

--- a/src/pages/politica-de-privacidade.tsx
+++ b/src/pages/politica-de-privacidade.tsx
@@ -118,11 +118,9 @@ export default function PrivacityPolicy() {
           <h4>2. FORMA DE UTILIZAÇÃO DOS DADOS COLETADOS</h4>
 
           <p>
-            Os dados coletados serão apenas utilizados para as finalidades
-            institucionais do DadosJusBr. Em linhas gerais, utilizamos os dados
-            para: (i) nos comunicar com as pessoas interessadas; (ii) divulgar
-            as nossas atividades; (iii) promover a associação de interessados à
-            entidade, nos termos do nosso Estatuto Social; e (iv) identificar as
+            O DadosjusBR utliza os dados para: (i) nos comunicar com as pessoas
+            interessadas; (ii) divulgar as nossas atividades; (iii) promover a associação
+            de interessados à entidade; e (iv) identificar as
             características de acesso e navegação em nosso site.
           </p>
 

--- a/src/pages/politica-de-privacidade.tsx
+++ b/src/pages/politica-de-privacidade.tsx
@@ -141,7 +141,7 @@ export default function PrivacityPolicy() {
           <h4>4. POR QUANTO TEMPO GUARDAMOS ESSES DADOS?</h4>
 
           <p>
-            O DadosJusBr apenas guardará os seus dados pelo tempo necessário
+            O DadosJusBr apenas manterá os seus dados armazenados pelo tempo necessário
             para o cumprimento das finalidades para as quais foram coletados. A
             fim de manter o histórico de solicitações recebidas, os dados
             pessoais fornecidos serão anonimizados no prazo máximo de 3 meses

--- a/src/pages/politica-de-privacidade.tsx
+++ b/src/pages/politica-de-privacidade.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import Footer from '../components/Footer';
 import Header from '../components/Header';
 
-export default function PrivacityPolitics() {
+export default function PrivacityPolicy() {
   return (
     <Page>
       <Head>

--- a/src/pages/politica-de-privacidade.tsx
+++ b/src/pages/politica-de-privacidade.tsx
@@ -1,0 +1,228 @@
+import Head from 'next/head';
+import styled from 'styled-components';
+import Footer from '../components/Footer';
+import Header from '../components/Header';
+
+export default function PrivacityPolitics() {
+  return (
+    <Page>
+      <Head>
+        <title>Política de Privacidade do DadosJusBr</title>
+      </Head>
+      <Header theme="LIGHT" />
+      <Container>
+        <h1>DadosJusBr Um compromisso com a sua privacidade!</h1>
+        <MainSection>
+          <p>
+            Esta Política de Privacidade dispõe sobre o processo de coleta,
+            armazenamento, utilização, tratamento, compartilhamento e exclusão
+            de dados pessoais eventualmente coletados pelo DadosJusBr.
+          </p>
+
+          <p>
+            O DadosJusBr busca respeitar integralmente a Lei Geral de Proteção
+            de Dados Pessoais - LGPD (Lei Federal nº 13.709/2018) e declara o
+            compromisso da entidade de preservar a privacidade e o sigilo dos
+            dados pessoais. Nos preocupamos com a sua privacidade, honra e
+            imagem, e utilizaremos todos os meios possíveis para protegê-las.
+          </p>
+
+          <p>
+            De acordo com a LGPD e para fins desta política, considera-se dado
+            pessoal toda e qualquer informação relacionada a pessoa natural
+            identificada ou identificável, o que poderá incluir nome, e-mail,
+            endereço, número do CPF, RG, dados de localização e endereço IP, sem
+            prejuízo de outros dados que, em conjunto, permitam identificar uma
+            pessoa de forma inequívoca.
+          </p>
+
+          <p>
+            Os dados pessoais sensíveis são aqueles sobre origem racial ou
+            étnica, convicção religiosa, opinião política, filiação a sindicato
+            ou a organização de caráter religioso, filosófico ou político, dado
+            referente à saúde ou à vida sexual, dado genético ou biométrico,
+            quando vinculado a uma pessoa.
+          </p>
+
+          <p>
+            Ao acessar este site, você declara estar ciente das normas desta
+            política e ter feito a leitura completa e atenta das regras aqui
+            contidas, conferindo, assim, seu livre e expresso consentimento com
+            esta Política de Privacidade.
+          </p>
+
+          <h4>1. QUAIS DADOS O DADOSJUSBR PODE COLETAR?</h4>
+
+          <CollectList>
+            <li>
+              <p>
+                Visita ao site do DadosJusBr: durante a visita ao site, podemos
+                registrar alguns dados, como dados relativos ao seu provedor de
+                internet, sistema operacional, navegador, configurações de vídeo
+                e páginas acessadas.
+              </p>
+
+              <p>
+                Esses dados são coletados por meio de cookies. Você pode ajustar
+                suas configurações de navegador para desabilitar os cookies ou
+                deletá-los. Caso estejam habilitados, nós (e os terceiros
+                previamente mencionados) emitiremos cookies quando você
+                interagir com o nosso site. Somente coletamos, via cookies,
+                dados essenciais para o funcionamento do nosso site e para as
+                métricas de acesso. Não compartilhamos esses dados com
+                terceiros, além daqueles responsáveis pelos próprios cookies.
+              </p>
+
+              <p>
+                Com exceção dos dados de <strong>cookies</strong>, não serão
+                automaticamente coletados dados pessoais; informações dessa
+                natureza serão registradas em nossos bancos de dados apenas
+                quando um formulário for preenchido voluntariamente pelo
+                usuário.
+              </p>
+
+              <p>
+                Além disso, o site do DadosJusBr usa a ferramenta{' '}
+                <strong>Google Analytics</strong> que analisa suas interações e
+                como você usa o site. O Google Analytics é um serviço de web
+                analytics que identifica os seus padrões de navegação no nosso
+                site e gera relatórios sobre essas atividades, para que possamos
+                melhorar o site do DadosJusBr. Para fazer isso, são
+                coletados/compartilhados dados pessoais para contato, como você
+                usa o site e dados que o identificam. O tratamento desses dados
+                é regido pela{' '}
+                <a
+                  href="https://policies.google.com/privacy"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  política de privacidade do Google.
+                </a>
+              </p>
+            </li>
+          </CollectList>
+
+          <p>
+            Para fins das atividades aqui mencionadas <strong>não serão</strong>{' '}
+            coletados <strong>dados pessoais sensíveis.</strong>
+          </p>
+
+          <p>
+            Os dados serão adquiridos mediante prévio consentimento coletado
+            individualmente de forma clara, específica e legítima. O
+            consentimento poderá ser alterado pelo titular a qualquer tempo para
+            conceder novas permissões, retirar seu consentimento para permissões
+            antigas e solicitar a exclusão de seus dados de nossa base de dados,
+            conforme indicado no Item 5 abaixo.
+          </p>
+
+          <h4>2. COMO UTILIZAMOS OS DADOS COLETADOS?</h4>
+
+          <p>
+            Os dados coletados serão apenas utilizados para as finalidades
+            institucionais do DadosJusBr. Em linhas gerais, utilizamos os dados
+            para: (i) nos comunicar com as pessoas interessadas; (ii) divulgar
+            as nossas atividades; (iii) promover a associação de interessados à
+            entidade, nos termos do nosso Estatuto Social; e (iv) identificar as
+            características de acesso e navegação em nosso site.
+          </p>
+
+          <h4>3. COM QUEM COMPARTILHAMOS SEUS DADOS?</h4>
+
+          <p>
+            De forma geral, o DadosJusBr não venderá, compartilhará, cederá ou
+            transmitirá seus dados pessoais a terceiros sem prévio
+            consentimento.
+          </p>
+
+          <p>
+            Nas hipóteses em que seja necessária a manipulação de seus dados por
+            fornecedores, o contrato de prestação de serviços contará com uma
+            cláusula de confidencialidade para proteção desses dados.
+          </p>
+
+          <h4>4. POR QUANTO TEMPO GUARDAMOS ESSES DADOS?</h4>
+
+          <p>
+            O DadosJusBr apenas guardará os seus dados pelo tempo necessário
+            para o cumprimento das finalidades para as quais foram coletados. A
+            fim de manter o histórico de solicitações recebidas, os dados
+            pessoais fornecidos serão anonimizados no prazo máximo de 3 meses
+            após a coleta dos dados.
+          </p>
+
+          <h4>5. COMO SOLICITAR ACESSO E EXCLUSÃO DE DADOS?</h4>
+
+          <p>
+            Os cookies de navegação podem ser apagados diretamente no seu
+            navegador mas no caso de dados no analytics o usuário poderá
+            solicitar uma cópia de suas informações pessoais a qualquer momento,
+            bem como solicitar a correção ou remoção dessas informações. Caso o
+            usuário deseje a exclusão imediata de seus dados, poderá, a qualquer
+            momento, solicitá-la por mensagem enviada à nossa equipe por meio do
+            e-mail:{' '}
+            <a
+              href="mailto:dadosjusbr@gmail.com"
+              target="_blank"
+              rel="noreferrer"
+            >
+              dadosjusbr@gmail.com
+            </a>
+          </p>
+          <p />
+        </MainSection>
+      </Container>
+      <Footer theme="LIGHT" />
+    </Page>
+  );
+}
+const Container = styled.div`
+  font-family: 'Roboto Condensed', sans-serif;
+  font-size: 3rem;
+  display: flex;
+  flex-direction: column;
+  margin: 0px 68px;
+  padding-top: 8rem;
+  padding-bottom: 8rem;
+  strong,
+  a {
+    font-size: 2rem;
+  }
+  a {
+    color: #3e5363;
+    text-decoration: underline;
+  }
+  h1 {
+    font-size: 3rem;
+    color: #3e5363;
+  }
+  @media (max-width: 600px) {
+    padding-top: 4rem;
+    padding-bottom: 4rem;
+    margin: 0px 20px;
+  }
+`;
+export const MainSection = styled.section`
+  display: flex;
+  & > * {
+    font-size: 2rem;
+    margin: 1rem 0;
+  }
+  flex-wrap: wrap;
+  margin-top: 2rem;
+  color: #3e5363;
+`;
+export const CollectList = styled.ul`
+  font-size: 1rem;
+  margin-left: 5rem;
+  li {
+    font-size: 2.5rem;
+  }
+  strong,
+  a {
+    font-size: 1.6rem;
+  }
+`;
+const Page = styled.div`
+  background-color: #fff;
+`;

--- a/src/pages/politica-de-privacidade.tsx
+++ b/src/pages/politica-de-privacidade.tsx
@@ -138,7 +138,7 @@ export default function PrivacityPolicy() {
             cláusula de confidencialidade para proteção desses dados.
           </p>
 
-          <h4>4. POR QUANTO TEMPO GUARDAMOS ESSES DADOS?</h4>
+          <h4>4. TEMPO DE ARMAZENAMENTO DOS DADOS</h4>
 
           <p>
             O DadosJusBr apenas manterá os seus dados armazenados pelo tempo necessário

--- a/src/pages/politica-de-privacidade.tsx
+++ b/src/pages/politica-de-privacidade.tsx
@@ -148,7 +148,7 @@ export default function PrivacityPolicy() {
             após a coleta dos dados.
           </p>
 
-          <h4>5. COMO SOLICITAR ACESSO E EXCLUSÃO DE DADOS?</h4>
+          <h4>5. SOLICITAR ACESSO E EXCLUSÃO DE DADOS</h4>
 
           <p>
             Os cookies de navegação podem ser apagados diretamente no seu

--- a/src/pages/politica-de-privacidade.tsx
+++ b/src/pages/politica-de-privacidade.tsx
@@ -74,9 +74,8 @@ export default function PrivacityPolicy() {
               </p>
 
               <p>
-                Com exceção dos dados de <strong>cookies</strong>, não serão
-                automaticamente coletados dados pessoais; informações dessa
-                natureza serão registradas em nossos bancos de dados apenas
+                Não serão automaticamente coletados dados pessoais; informações
+                dessa natureza serão registradas em nossos bancos de dados apenas
                 quando um formulário for preenchido voluntariamente pelo
                 usuário.
               </p>

--- a/src/pages/politica-de-privacidade.tsx
+++ b/src/pages/politica-de-privacidade.tsx
@@ -51,7 +51,7 @@ export default function PrivacityPolicy() {
             esta Política de Privacidade.
           </p>
 
-          <h4>1. QUAIS DADOS O DADOSJUSBR PODE COLETAR?</h4>
+          <h4>1. DADOS POSSIVELMENTE COLETADOS PELO DADOSJUSBR</h4>
 
           <CollectList>
             <li>


### PR DESCRIPTION
Esse PR:
* cria um React Context para gerenciar as políticas de privacidade 
* bloqueia o analytics de rodar caso o usuário não aceite a politica de cookies
* adiciona um pop up para permitir que o usuário aceite ou não a politica de cookies
* cria uma tela de politica de privacidade com um template baseado no da transparência, mas atendendo aos requisitos do dadosJus