### PR TITLE
Cria uma gaveta de navegação para o menu no mobile

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,18 @@
 import { useState } from 'react';
-import { Container, Box, Grid, Link, Button } from '@mui/material';
+import {
+  Container,
+  Box,
+  Grid,
+  Link,
+  Button,
+  Drawer,
+  List,
+  ListItem,
+  IconButton,
+  ListItemButton,
+  ListItemText,
+} from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
 
 function Header() {
   const [pages] = useState([
@@ -29,6 +42,8 @@ function Header() {
       anchor: '/sobre',
     },
   ]);
+  const [openDrawer, setOpenDrawer] = useState(false);
+
   return (
     <Container fixed>
       <Box
@@ -44,7 +59,7 @@ function Header() {
           alignItems="center"
           justifyContent="center"
         >
-          <Grid item xs={3} md={2}>
+          <Grid item xs={4} md={2}>
             <Link href="/">
               <img
                 src="/img/header/icon_dadosjusbr_default.svg"
@@ -55,26 +70,51 @@ function Header() {
           </Grid>
           <Grid
             item
-            xs={9}
+            xs={8}
             md={10}
             display="flex"
             alignItems="center"
             justifyContent="flex-end"
           >
-            {pages.map(page => (
-              <Button
-                key={page.key}
-                variant="text"
-                color="info"
-                size="large"
-                href={page.anchor}
+            <Box sx={{ display: { xs: 'none', md: 'block' } }}>
+              {pages.map(page => (
+                <Button
+                  key={page.key}
+                  variant="text"
+                  color="info"
+                  size="large"
+                  href={page.anchor}
+                >
+                  {page.title}
+                </Button>
+              ))}
+            </Box>
+            <Box sx={{ display: { xs: 'block', md: 'none' } }}>
+              <IconButton
+                color="inherit"
+                aria-label="open drawer"
+                edge="start"
+                onClick={() => setOpenDrawer(!openDrawer)}
               >
-                {page.title}
-              </Button>
-            ))}
+                <MenuIcon />
+              </IconButton>
+            </Box>
           </Grid>
         </Grid>
       </Box>
+      <Drawer open={openDrawer} onClose={() => setOpenDrawer(false)}>
+        <Box pt={4} sx={{ width: 250 }}>
+          <List>
+            {pages.map(page => (
+              <ListItem key={page.key} disablePadding>
+                <ListItemButton component="a" href={page.anchor}>
+                  <ListItemText primary={page.title} />
+                </ListItemButton>
+              </ListItem>
+            ))}
+          </List>
+        </Box>
+      </Drawer>
     </Container>
   );
 }


### PR DESCRIPTION
## Resultado esperado:

- o menu principal deve permanecer o mesmo em telas de médias pra grandes.
- o menu principal deve ficar escondido e aberto usando um botão em telas pequenas.