### PR TITLE
Orgão ano atual

### DIFF
--- a/src/pages/grupo/[summary].tsx
+++ b/src/pages/grupo/[summary].tsx
@@ -81,8 +81,8 @@ const GraphWithNavigation: React.FC<{ id: string; title: string }> = ({
   // this state is used to store the api fetched data after fetch it
   const [data, setData] = useState<any[]>([]);
   const [summaryPackage, setSummaryPackage] = useState<any>();
-  // this state is used to check if the actual date is at least 8 days away from January 1st
-  const [year, setYear] = useState(new Date().getDate() <= 8 && new Date().getMonth() + 1 == 1 ? new Date().getFullYear() - 1 : new Date().getFullYear());
+  // this state is used to check if the actual date is at least 17 days away from January 1st. The data collect always happen in the 17th day, so we set the default year after this first data collect of the year.
+  const [year, setYear] = useState(new Date().getDate() <= 17 && new Date().getMonth() + 1 == 1 ? new Date().getFullYear() - 1 : new Date().getFullYear());
   const [agencyData, setAgencyData] = useState<any>();
   const [dataLoading, setDataLoading] = useState(true);
   // the useMemo hook is used to create an memoization (https://en.wikipedia.org/wiki/Memoization) with a state, it's used to avoid the need to recalculate values in screen rederization, here it's used to check if the date is valid to active the nextDate and the previousDate button using dates between 2018-2021 (https://pt-br.reactjs.org/docs/hooks-reference.html#usememo)

--- a/src/pages/grupo/[summary].tsx
+++ b/src/pages/grupo/[summary].tsx
@@ -81,7 +81,7 @@ const GraphWithNavigation: React.FC<{ id: string; title: string }> = ({
   // this state is used to store the api fetched data after fetch it
   const [data, setData] = useState<any[]>([]);
   const [summaryPackage, setSummaryPackage] = useState<any>();
-  const [year, setYear] = useState(new Date().getFullYear() - 1);
+  const [year, setYear] = useState(new Date().getFullYear());
   const [agencyData, setAgencyData] = useState<any>();
   const [dataLoading, setDataLoading] = useState(true);
   // the useMemo hook is used to create an memoization (https://en.wikipedia.org/wiki/Memoization) with a state, it's used to avoid the need to recalculate values in screen rederization, here it's used to check if the date is valid to active the nextDate and the previousDate button using dates between 2018-2021 (https://pt-br.reactjs.org/docs/hooks-reference.html#usememo)

--- a/src/pages/grupo/[summary].tsx
+++ b/src/pages/grupo/[summary].tsx
@@ -81,7 +81,8 @@ const GraphWithNavigation: React.FC<{ id: string; title: string }> = ({
   // this state is used to store the api fetched data after fetch it
   const [data, setData] = useState<any[]>([]);
   const [summaryPackage, setSummaryPackage] = useState<any>();
-  const [year, setYear] = useState(new Date().getFullYear());
+  // this state is used to check if the actual date is at least 8 days away from January 1st
+  const [year, setYear] = useState(new Date().getDate() <= 8 && new Date().getMonth() + 1 == 1 ? new Date().getFullYear() - 1 : new Date().getFullYear());
   const [agencyData, setAgencyData] = useState<any>();
   const [dataLoading, setDataLoading] = useState(true);
   // the useMemo hook is used to create an memoization (https://en.wikipedia.org/wiki/Memoization) with a state, it's used to avoid the need to recalculate values in screen rederization, here it's used to check if the date is valid to active the nextDate and the previousDate button using dates between 2018-2021 (https://pt-br.reactjs.org/docs/hooks-reference.html#usememo)


### PR DESCRIPTION
Esse PR
* FIX #198 
* Define o ano de requisição de dados padrão de acordo com o ano atual do usuário
* O ano atual do usuário será válido apenas após o dia 17 de janeiro, contornando o problema de os dados abrirem em um ano sem coleta, pois a primeira coleta do ano acontece no dia 16 de janeiro