### PR TITLE
Definir a data padrão dos dados para o ano atual

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -78,7 +78,8 @@ export default function Index({
     return `${MONTHS[d.getMonth() + 1]} de ${d.getFullYear()}`;
   }, [endDate]);
   const [completeChartData, setCompleteChartData] = useState<any[]>([]);
-  const [year, setYear] = useState(new Date().getFullYear() - 1);
+  // this state is used to check if the actual date is at least 17 days away from January 1st. The data collect always happen in the 17th day, so we set the default year after this first data collect of the year.
+  const [year, setYear] = useState(new Date().getDate() <= 17 && new Date().getMonth() + 1 == 1 ? new Date().getFullYear() - 1 : new Date().getFullYear());
   const [loading, setLoading] = useState(true);
   const nextDateIsNavigable = useMemo<boolean>(
     () => year !== new Date().getFullYear(),


### PR DESCRIPTION
Esse PR:
* Muda a data de requisição dos dados na página inicial (index.tsx) para o ano atual.

Objetivo:
* Alcançar o padrão estabelecido na página de grupos (sempre mostrando os dados do ano mais recente).

> Página inicial antes das mudanças
![image](https://user-images.githubusercontent.com/64742095/192615577-dcd6df99-fc80-47ec-88c5-33237365ec00.png)

> Página inicial depois das mudanças
![image](https://user-images.githubusercontent.com/64742095/192615755-c7cbe3c8-66ee-49cb-b521-2967c9412b99.png)

