### PR TITLE
Melhorias na página OMA

### DIFF
--- a/src/components/MonthPopover.tsx
+++ b/src/components/MonthPopover.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import Popover from '@mui/material/Popover';
+import Typography from '@mui/material/Typography';
+import MONTHS from '../@types/MONTHS';
+import { useRouter } from 'next/router';
+import { Button } from '@mui/material';
+
+export default function MonthPopover({ children, agency, year }) {
+  const router = useRouter();
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
+    null,
+  );
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const selectMonth = (month: number) => {
+    handleClose();
+    router.push(`/orgao/${agency}/${year}/${month}`);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popover' : undefined;
+
+  const list = [];
+  for (const i in MONTHS) {
+    if (Number.isNaN(Number(i))) {
+      list.push(i);
+    }
+  }
+
+  return (
+    <div>
+      <Typography
+        component="span"
+        variant="h4"
+        aria-describedby={id}
+        onClick={handleClick}
+      >
+        {children}
+      </Typography>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+      >
+        <Typography sx={{ p: 2 }}>
+          {list.map(month => (
+            <Typography
+              sx={{
+                width: 145,
+                cursor: 'pointer',
+              }}
+              onClick={selectMonth.bind(this, list.indexOf(month) + 1)}
+            >
+              <Button sx={{ width: '100%' }}>{month}</Button>
+            </Typography>
+          ))}
+        </Typography>
+      </Popover>
+    </div>
+  );
+}

--- a/src/components/OmaChart.tsx
+++ b/src/components/OmaChart.tsx
@@ -12,6 +12,7 @@ import {
   List,
   ListItem,
   ListItemAvatar,
+  ListItemIcon,
   ListItemText,
   Paper,
   Stack,
@@ -27,6 +28,7 @@ import InfoIcon from '@mui/icons-material/Info';
 import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 import IosShareIcon from '@mui/icons-material/IosShare';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import { Done, Close } from '@mui/icons-material';
 
 import * as url from '../url';
 import ShareModal from './ShareModal';
@@ -52,19 +54,79 @@ function ShowAcesso(props) {
   const acesso = props.children;
   switch (acesso) {
     case 'ACESSO_DIRETO':
-      return <span>Acesso direto</span>;
+      return (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <ListItemIcon>
+            <Done color="success" />
+          </ListItemIcon>
+          <span>Acesso direto</span>
+        </div>
+      );
       break;
     case 'AMIGAVEL_PARA_RASPAGEM':
-      return <span>Amigável para raspagem</span>;
+      return (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <ListItemIcon>
+            <Done color="warning" />
+          </ListItemIcon>
+          <span>Amigável para raspagem</span>
+        </div>
+      );
       break;
     case 'RASPAGEM_DIFICULTADA':
-      return <span>Raspagem dificultada</span>;
+      return (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <ListItemIcon>
+            <Done color="warning" />
+          </ListItemIcon>
+          <span>Raspagem dificultada</span>
+        </div>
+      );
       break;
     case 'NECESSITA_SIMULACAO_USUARIO':
-      return <span>É possível navegar no html do site</span>;
+      return (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <ListItemIcon>
+            <Done color="warning" />
+          </ListItemIcon>
+          <span>É possível navegar no html do site</span>
+        </div>
+      );
       break;
     default:
-      return <span>--</span>;
+      return (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <ListItemIcon>
+            <Close color="error" />
+          </ListItemIcon>
+          <span>--</span>
+        </div>
+      );
       break;
   }
 }
@@ -73,13 +135,47 @@ function ShowTipoDado(props) {
   const tipo = props.tipo;
   switch (tipo) {
     case 'SUMARIZADO':
-      return <span>Disponibiliza dados de {texto} sumarizados</span>;
+      return (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <Done color="success" />
+          <span>Disponibiliza dados de {texto} sumarizados</span>
+        </div>
+      );
       break;
     case 'DETALHADO':
-      return <span>Disponibiliza dados de {texto} detalhados</span>;
+      return (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <ListItemIcon>
+            <Done color="success" />
+          </ListItemIcon>
+          <span>Disponibiliza dados de {texto} detalhados</span>
+        </div>
+      );
       break;
     default:
-      return <span>Não disponibiliza dados de {texto}</span>;
+      return (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <ListItemIcon>
+            <Close color="error" />
+          </ListItemIcon>
+          <span> Não disponibiliza dados de {texto} </span>
+        </div>
+      );
       break;
   }
 }
@@ -171,7 +267,7 @@ const OMASummary: React.FC<OMASummaryProps> = ({
                     <IconButton>
                       <InfoIcon />
                     </IconButton>
-                  </Tooltip>
+                  </Tooltip>{' '}
                 </Typography>
                 <List dense>
                   <ListItem>
@@ -260,22 +356,37 @@ const OMASummary: React.FC<OMASummaryProps> = ({
                 </Typography>
                 <Typography variant="h6" textAlign="center">
                   Índice de transparência:{' '}
-                  <b>{mi.Score?.indice_transparencia.toFixed(2)}</b>
+                  <b>
+                    {mi.Score?.indice_transparencia == undefined
+                      ? 'Indisponível'
+                      : mi.Score?.indice_transparencia.toFixed(2)}
+                  </b>
                 </Typography>
                 <Grid container>
                   <Grid item xs={12} md={6}>
                     <List dense>
                       <ListItem>
                         <ListItemText
-                          primary={`Índice de completude: ${mi.Score?.indice_completude.toFixed(
-                            2,
-                          )}`}
+                          primary={`Índice de completude: ${
+                            mi.Score?.indice_completude == undefined
+                              ? 'Indisponível'
+                              : mi.Score?.indice_completude.toFixed(2)
+                          }`}
                           primaryTypographyProps={{
                             variant: 'h6',
                           }}
                         />
                       </ListItem>
                       <ListItem>
+                        {mi.Meta?.tem_lotacao == null ? (
+                          <ListItemIcon>
+                            <Close color="error" />
+                          </ListItemIcon>
+                        ) : (
+                          <ListItemIcon>
+                            <Done color="success" />
+                          </ListItemIcon>
+                        )}
                         <ListItemText
                           primary="Tem lotação"
                           sx={{
@@ -286,6 +397,15 @@ const OMASummary: React.FC<OMASummaryProps> = ({
                         />
                       </ListItem>
                       <ListItem>
+                        {mi.Meta?.tem_cargo == null ? (
+                          <ListItemIcon>
+                            <Close color="error" />
+                          </ListItemIcon>
+                        ) : (
+                          <ListItemIcon>
+                            <Done color="success" />
+                          </ListItemIcon>
+                        )}
                         <ListItemText
                           primary="Tem cargo"
                           sx={{
@@ -296,6 +416,15 @@ const OMASummary: React.FC<OMASummaryProps> = ({
                         />
                       </ListItem>
                       <ListItem>
+                        {mi.Meta?.tem_matricula == null ? (
+                          <ListItemIcon>
+                            <Close color="error" />
+                          </ListItemIcon>
+                        ) : (
+                          <ListItemIcon>
+                            <Done color="success" />
+                          </ListItemIcon>
+                        )}
                         <ListItemText
                           primary="Tem matrícula e nome"
                           sx={{
@@ -338,15 +467,24 @@ const OMASummary: React.FC<OMASummaryProps> = ({
                     <List dense>
                       <ListItem>
                         <ListItemText
-                          primary={`Índice de facilidade: ${mi.Score?.indice_facilidade.toFixed(
-                            2,
-                          )}`}
+                          primary={`Índice de facilidade: ${
+                            mi.Score?.indice_facilidade == undefined
+                              ? 'Indisponível'
+                              : mi.Score?.indice_facilidade.toFixed(2)
+                          }`}
                           primaryTypographyProps={{
                             variant: 'h6',
                           }}
                         />
                       </ListItem>
                       <ListItem>
+                        <ListItemIcon>
+                          {mi.Meta?.login_nao_necessario == null ? (
+                            <Close color="error" />
+                          ) : (
+                            <Done color="success" />
+                          )}
+                        </ListItemIcon>
                         <ListItemText
                           primary="Não é necessário login"
                           sx={{
@@ -357,6 +495,13 @@ const OMASummary: React.FC<OMASummaryProps> = ({
                         />
                       </ListItem>
                       <ListItem>
+                        <ListItemIcon>
+                          {mi.Meta?.captcha_nao_necessario == null ? (
+                            <Close color="error" />
+                          ) : (
+                            <Done color="success" />
+                          )}
+                        </ListItemIcon>
                         <ListItemText
                           primary="Não é necessário captcha"
                           sx={{
@@ -372,6 +517,13 @@ const OMASummary: React.FC<OMASummaryProps> = ({
                         />
                       </ListItem>
                       <ListItem>
+                        <ListItemIcon>
+                          {mi.Meta?.manteve_consistencia_no_formato == null ? (
+                            <Close color="error" />
+                          ) : (
+                            <Done color="success" />
+                          )}
+                        </ListItemIcon>
                         <ListItemText
                           primary="Manteve consistência no formato"
                           sx={{
@@ -383,6 +535,13 @@ const OMASummary: React.FC<OMASummaryProps> = ({
                         />
                       </ListItem>
                       <ListItem>
+                        <ListItemIcon>
+                          {mi.Meta?.dados_estritamente_tabulares == null ? (
+                            <Close color="error" />
+                          ) : (
+                            <Done color="success" />
+                          )}
+                        </ListItemIcon>
                         <ListItemText
                           primary="Dados estritamente tabulares"
                           sx={{

--- a/src/components/OmaChart.tsx
+++ b/src/components/OmaChart.tsx
@@ -316,7 +316,7 @@ const OMASummary: React.FC<OMASummaryProps> = ({
                       </Avatar>
                     </ListItemAvatar>
                     <ListItemText
-                      primary={`Total de membros ${totalMembers}`}
+                      primary={`Total de membros: ${totalMembers}`}
                     />
                   </ListItem>
                 </List>
@@ -560,7 +560,7 @@ const OMASummary: React.FC<OMASummaryProps> = ({
           </Grid>
           <Grid item xs={12}>
             <Paper elevation={0}>
-              <Box pt={4} py={4}>
+              <Box pt={4} py={4} px={2}>
                 <Typography variant="h6" textAlign="center">
                   Total de remunerações de membros por mês em {year}
                 </Typography>

--- a/src/pages/orgao/[agency]/[year]/[month].tsx
+++ b/src/pages/orgao/[agency]/[year]/[month].tsx
@@ -22,6 +22,7 @@ import Header from '../../../../components/Header';
 import api from '../../../../services/api';
 import OMASummary from '../../../../components/OmaChart';
 import ErrorTable from '../../../../components/ErrorTable';
+import MonthPopover from '../../../../components/MonthPopover';
 
 function UnixToHumanDate(unix) {
   const d = new Date(unix * 1000);
@@ -133,9 +134,15 @@ export default function OmaPage({
               </IconButton>
             </Grid>
             <Grid item>
-              <Typography component="span" variant="h4">
-                {MONTHS[month]} {year}
-              </Typography>
+              <MonthPopover agency={agency} year={year}>
+                <Typography
+                  variant="h4"
+                  textAlign="center"
+                  sx={{ cursor: 'pointer' }}
+                >
+                  {MONTHS[month]} {year}
+                </Typography>
+              </MonthPopover>
             </Grid>
             <Grid item>
               <IconButton


### PR DESCRIPTION
Esse PR:
* Adiciona padding no card de remunerações para seguir o padrão do card de transparência na página de OMA 
* Corrige o item 1 da issue #186 
* Corrige o item 3 da issue #186 

Página depois das correções:
![image](https://user-images.githubusercontent.com/64742095/195737137-b155d843-2639-48ff-86e0-cd0e6f5a0664.png)
> * O símbolo "done" na cor amarela significa que aquele requisito foi cumprido pelo órgão, porém não da forma mais otimizada, que nesse caso, seria o "acesso direto".
> * A simbologia e a cor foram escolhida justamente para passar essa sensação de "feito", que vem do símbolo, e "dificuldades/atenção" provida pela cor amarela.

Popover para o usuário ir diretamente para o mês desejado:
![image](https://user-images.githubusercontent.com/64742095/195739059-e20b987c-9a86-4f34-8a80-b2569540dc5e.png)

Popover funcionando:
![daosjusbr-OMA](https://user-images.githubusercontent.com/64742095/195739743-8971b66d-ce75-40f4-9cdc-2afb818cb927.gif)


