### PR TITLE
Adicionando as definições de membro e servidor ao tooltip

### DIFF
--- a/src/components/RemunerationBarGraph.tsx
+++ b/src/components/RemunerationBarGraph.tsx
@@ -113,7 +113,17 @@ const RemunerationBarGraph: React.FC<RemunerationBarGraphProps> = ({
                   title={
                     <Typography fontSize="0.8rem">
                       <p>
-                        <b>Salário:</b> valor recebido de acordo com a prestação
+                        <b>Membros:</b> Participantes ativos do órgao, incluindo
+                        os servidores públicos, os militares e os membros do
+                        Poder Judiciário.
+                      </p>
+                      <p>
+                        <b>Servidor:</b> Funcionário público que exerce cargo ou
+                        função pública, com vínculo empregatício, e que recebe
+                        remuneração fixa ou variável.
+                      </p>
+                      <p>
+                        <b>Salário:</b> Valor recebido de acordo com a prestação
                         de serviços, em decorrência do contrato de trabalho.
                       </p>
                       <p>


### PR DESCRIPTION
Esse PR:
* FIX #181 

Resultado: 
![image](https://user-images.githubusercontent.com/64742095/196710328-c85bba7f-1d45-4303-8209-a13437d89f58.png)

Texto adicionado ao tooltip:
> <b>Membros:</b> Participantes ativos do órgao, incluindo
                        os servidores públicos, os militares e os membros do
                        Poder Judiciário.
                      </p>
                      <p>
                        <b>Servidor:</b> Funcionário público que exerce cargo ou
                        função pública, com vínculo empregatício, e que recebe
                        remuneração fixa ou variável.
                       </p>