### PR TITLE
Baixar PNG dos gráficos

### DIFF
--- a/src/components/RemunerationBarGraph.tsx
+++ b/src/components/RemunerationBarGraph.tsx
@@ -305,7 +305,24 @@ const RemunerationBarGraph: React.FC<RemunerationBarGraphProps> = ({
                             },
                             stacked: true,
                             toolbar: {
-                              show: false,
+                              show: true,
+                              export: {
+                                svg: {
+                                  filename: `remuneracoes-membros${
+                                    agency ? `- ${agency.aid}` : ''
+                                  }-${year}`,
+                                },
+                                png: {
+                                  filename: `remuneracoes-membros${
+                                    agency ? `- ${agency.aid}` : ''
+                                  }-${year}`,
+                                },
+                                csv: {
+                                  filename: `remuneracoes-membros${
+                                    agency ? `- ${agency.aid}` : ''
+                                  }-${year}`,
+                                },
+                              },
                             },
                             zoom: {
                               enabled: true,
@@ -376,6 +393,7 @@ const RemunerationBarGraph: React.FC<RemunerationBarGraphProps> = ({
                             title: {
                               text: 'Total de Remunerações',
                               offsetY: 10,
+                              offsetX: -5.5,
                               style: {
                                 fontSize: '14px',
                                 fontWeight: 'bold',
@@ -389,7 +407,7 @@ const RemunerationBarGraph: React.FC<RemunerationBarGraphProps> = ({
                               maxWidth: 160,
                               style: {
                                 colors: [],
-                                fontSize: '16px',
+                                fontSize: '11px',
                                 fontFamily: 'Roboto Condensed, sans-serif',
                                 fontWeight: 600,
                                 cssClass: 'apexcharts-yaxis-label',

--- a/src/components/RemunerationBarGraph.tsx
+++ b/src/components/RemunerationBarGraph.tsx
@@ -291,7 +291,7 @@ const RemunerationBarGraph: React.FC<RemunerationBarGraphProps> = ({
               ) : (
                 <>
                   {data.length > 0 ? (
-                    <Box>
+                    <Box pr={2}>
                       <Chart
                         options={{
                           colors: ['#97BB2F', '#2FBB96', '#2c3236', '#ffab00'],


### PR DESCRIPTION
Esse PR:
* FIX #183 
* Adiciona também a opção de baixar o SVG do gráfico

> ![image](https://user-images.githubusercontent.com/64742095/197517081-f5928a04-932a-487c-80cf-6a6946cabbd4.png)
> ![image](https://user-images.githubusercontent.com/64742095/197517168-5cf9c495-426d-439f-b999-c67bbcba8f3c.png)

