### PR TITLE
Botões da legenda dos gráfico de remunerações

### DIFF
--- a/src/components/RemunerationBarGraph.tsx
+++ b/src/components/RemunerationBarGraph.tsx
@@ -153,6 +153,7 @@ const RemunerationBarGraph: React.FC<RemunerationBarGraphProps> = ({
             >
               <Grid item textAlign="center">
                 <SalarioButton
+                  sx={{ backgroundColor: '#2fbb95' }}
                   onClick={e => {
                     if (hidingWage) {
                       e.currentTarget.classList.remove('active');
@@ -184,7 +185,7 @@ const RemunerationBarGraph: React.FC<RemunerationBarGraphProps> = ({
                 {matches ? (
                   <>
                     <SemDadosButton
-                      sx={{ mt: 2 }}
+                      sx={{ mt: 2, backgroundColor: '#3E5363' }}
                       onClick={e => {
                         if (hidingNoData) {
                           e.currentTarget.classList.remove('active');
@@ -203,6 +204,7 @@ const RemunerationBarGraph: React.FC<RemunerationBarGraphProps> = ({
               </Grid>
               <Grid item textAlign="center">
                 <BeneficiosButton
+                  sx={{ backgroundColor: '#96bb2f' }}
                   onClick={e => {
                     if (hidingBenefits) {
                       e.currentTarget.classList.remove('active');
@@ -235,6 +237,7 @@ const RemunerationBarGraph: React.FC<RemunerationBarGraphProps> = ({
                 <>
                   <Grid item textAlign="center">
                     <SemDadosButton
+                      sx={{ backgroundColor: '#3E5363' }}
                       onClick={e => {
                         if (hidingNoData) {
                           e.currentTarget.classList.remove('active');

--- a/src/components/RemunerationBarGraph.tsx
+++ b/src/components/RemunerationBarGraph.tsx
@@ -23,15 +23,9 @@ import NotCollecting from './NotCollecting';
 
 const Chart = dynamic(() => import('react-apexcharts'), { ssr: false });
 
-const SalarioButton = styled(IconButton)({
-  backgroundColor: '#2fbb95',
-});
-const BeneficiosButton = styled(IconButton)({
-  backgroundColor: '#96bb2f',
-});
-const SemDadosButton = styled(IconButton)({
-  backgroundColor: '#3E5363',
-});
+const SalarioButton = styled(IconButton)({});
+const BeneficiosButton = styled(IconButton)({});
+const SemDadosButton = styled(IconButton)({});
 
 export interface RemunerationBarGraphProps {
   year: number;


### PR DESCRIPTION
Esse PR: 
* Corrige o erro em que os botões da legenda do gráfico de remunerações estavam sem cor no ambiente de produção.

Antes: 
![image](https://user-images.githubusercontent.com/64742095/197524653-0d1d8778-89ef-4b62-8b84-abee3b6c1923.png)

Depois das alterações: 
![image](https://user-images.githubusercontent.com/64742095/197524904-87878503-1ead-48ac-8844-109289490584.png)
