### PR TITLE
Correções em tela para a captura de erro do fetchAgencyData()

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -37,7 +37,7 @@ const Footer: React.FC<FooterPropos> = ({ theme = 'DEFAULT' }) => (
               href="mailto:contato@dadosjusbr.org"
             >
               contato@dadosjusbr.org
-            </Link>{' '}
+            </Link>
             , ou visite nosso{' '}
             <Link
               color="inherit"

--- a/src/components/RemunerationBarGraph.tsx
+++ b/src/components/RemunerationBarGraph.tsx
@@ -552,22 +552,26 @@ const RemunerationBarGraph: React.FC<RemunerationBarGraphProps> = ({
                       />
                     </Box>
                   ) : (
-                    <div>Não há dados para esse ano</div>
+                    <Typography variant="body1" mt={2} textAlign="center">
+                      Não há dados para esse ano.
+                    </Typography>
                   )}
                 </>
               )}
             </Box>
-            <Grid container display="flex" justifyContent="center">
-              <Grid
-                display="flex"
-                item
-                pb={4}
-                sx={{ width: '50%' }}
-                justifyContent="center"
-              >
-                <CrawlingDateTable data={data} dataLoading={dataLoading} />
+            {data && data.length > 0 && (
+              <Grid container display="flex" justifyContent="center">
+                <Grid
+                  display="flex"
+                  item
+                  pb={4}
+                  sx={{ width: '50%' }}
+                  justifyContent="center"
+                >
+                  <CrawlingDateTable data={data} dataLoading={dataLoading} />
+                </Grid>
               </Grid>
-            </Grid>
+            )}
           </Paper>
         </>
       )}

--- a/src/pages/grupo/[summary].tsx
+++ b/src/pages/grupo/[summary].tsx
@@ -113,6 +113,7 @@ const GraphWithNavigation: React.FC<{ id: string; title: string }> = ({
       setSummaryPackage(agency.SummaryPackage);
       setDataLoading(false);
     } catch (err) {
+      setDataLoading(false);
       console.log(err);
     }
   }


### PR DESCRIPTION
Notei que quando o método fetchAgencyData() lança algum erro o loading da tela continua aparecendo, o que dá a entender para o usuário que algo ainda está carregando. 

<img width="1602" alt="Screen Shot 2022-10-29 at 12 51 25" src="https://user-images.githubusercontent.com/22149001/198841231-8830717b-9b7b-4805-8463-59ce6316a48a.png">

Além disso, percebi que apenas a alteração do setDataLoading não era suficiente, já que o layout da mensagem de nenhum dado encontrado divergia do resto da página e havia a presença de um 0 devido à CrawlingDateTable no componente RemunerationBarGraph sem dados.

<img width="1591" alt="Screen Shot 2022-10-29 at 12 52 28" src="https://user-images.githubusercontent.com/22149001/198841302-acd1ccad-a7d7-4150-897b-60b0c366f490.png">

O resultado final ficou assim:

<img width="1328" alt="Screen Shot 2022-10-29 at 13 02 31" src="https://user-images.githubusercontent.com/22149001/198841423-60108df6-21c3-41e5-8383-2da3b9e6df44.png">
