### PR TITLE
Pesquisa avançada nas página de resumo

### DIFF
--- a/src/components/AgencyWithNavigation.tsx
+++ b/src/components/AgencyWithNavigation.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
 import ReactGA from 'react-ga';
 import {
   Container,
@@ -14,6 +15,7 @@ import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 import IosShareIcon from '@mui/icons-material/IosShare';
+import SearchIcon from '@mui/icons-material/Search';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
 import ShareModal from './ShareModal';
@@ -56,6 +58,7 @@ const AgencyPageWithNavigation: React.FC<AgencyPageWithNavigationProps> = ({
   const [selectedMonth, setSelectedMonth] = useState<number>(m);
   const previousDateIsNavigable = useMemo<boolean>(() => year !== 2018, [year]);
   const matches = useMediaQuery('(max-width:500px)');
+  const router = useRouter();
 
   return (
     <Container fixed>
@@ -133,6 +136,17 @@ const AgencyPageWithNavigation: React.FC<AgencyPageWithNavigationProps> = ({
               >
                 EXPLORAR POR MÊS
               </Button>
+              <Button
+                variant="outlined"
+                color="info"
+                startIcon={<SearchIcon />}
+                onClick={() => {
+                  router.push(`/pesquisar?anos=${year}&orgaos=${agency.aid}`);
+                }}
+              >
+                PESQUISA AVANÇADA
+              </Button>
+              {console.log(agency)}
             </Stack>
           </>
         )}

--- a/src/components/OmaChart.tsx
+++ b/src/components/OmaChart.tsx
@@ -29,6 +29,7 @@ import EmojiPeopleIcon from '@mui/icons-material/EmojiPeople';
 import InfoIcon from '@mui/icons-material/Info';
 import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 import IosShareIcon from '@mui/icons-material/IosShare';
+import SearchIcon from '@mui/icons-material/Search';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { Done, Close } from '@mui/icons-material';
 
@@ -238,6 +239,18 @@ const OMASummary: React.FC<OMASummaryProps> = ({
           href={url.downloadURL(fileLink)}
         >
           BAIXAR DADOS
+        </Button>
+        <Button
+          variant="outlined"
+          color="info"
+          startIcon={<SearchIcon />}
+          onClick={() => {
+            router.push(
+              `/pesquisar?anos=${year}&meses=${month}&orgaos=${agency}`,
+            );
+          }}
+        >
+          PESQUISA AVANÇADA
         </Button>
       </Stack>
       <ThemeProvider theme={light}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,6 +18,7 @@ import {
 import { ThemeProvider } from '@mui/material/styles';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import SearchIcon from '@mui/icons-material/Search';
 
 import Footer from '../components/Footer';
 import Header from '../components/Header';
@@ -79,7 +80,11 @@ export default function Index({
   }, [endDate]);
   const [completeChartData, setCompleteChartData] = useState<any[]>([]);
   // this state is used to check if the actual date is at least 17 days away from January 1st. The data collect always happen in the 17th day, so we set the default year after this first data collect of the year.
-  const [year, setYear] = useState(new Date().getDate() <= 17 && new Date().getMonth() + 1 == 1 ? new Date().getFullYear() - 1 : new Date().getFullYear());
+  const [year, setYear] = useState(
+    new Date().getDate() <= 17 && new Date().getMonth() + 1 == 1
+      ? new Date().getFullYear() - 1
+      : new Date().getFullYear(),
+  );
   const [loading, setLoading] = useState(true);
   const nextDateIsNavigable = useMemo<boolean>(
     () => year !== new Date().getFullYear(),
@@ -175,7 +180,12 @@ export default function Index({
               </Typography>
             </Grid>
             <Grid item>
-              <Button variant="outlined" size="large" href="/pesquisar">
+              <Button
+                variant="outlined"
+                size="large"
+                href="/pesquisar"
+                startIcon={<SearchIcon />}
+              >
                 Pesquisa avançada
               </Button>
             </Grid>
@@ -222,20 +232,20 @@ export default function Index({
                     </Grid>
                   </Grid>
                   <TabPanel value={value} index={0}>
-                      <IndexChartLegend />
-                      <img
-                        src="/img/indice_tjs.png"
-                        alt="Índice de transparência"
-                        width="100%"
-                      />
+                    <IndexChartLegend />
+                    <img
+                      src="/img/indice_tjs.png"
+                      alt="Índice de transparência"
+                      width="100%"
+                    />
                   </TabPanel>
                   <TabPanel value={value} index={1}>
-                      <IndexChartLegend />
-                      <img
-                        src="/img/indice_mps.png"
-                        alt="Índice de transparência"
-                        width="100%"
-                      />
+                    <IndexChartLegend />
+                    <img
+                      src="/img/indice_mps.png"
+                      alt="Índice de transparência"
+                      width="100%"
+                    />
                   </TabPanel>
                 </Grid>
               </Grid>


### PR DESCRIPTION
Esse PR:
* FIX #233 

UI modificada:
![image](https://user-images.githubusercontent.com/64742095/200580936-efa5027b-91b9-4a53-ae3e-691ac495e7fe.png)
> ícone de lupa no botão de pesquisar na página inicial

![image](https://user-images.githubusercontent.com/64742095/200581274-5d9b550e-1104-4780-addc-cbe826074a8c.png)
> botão de pesquisa avançada nas página de resumo por mês e por ano
