### PR TITLE
Removendo a repetição de código na página de OMA

### DIFF
--- a/src/components/OmaChart.tsx
+++ b/src/components/OmaChart.tsx
@@ -199,8 +199,9 @@ const OMASummary: React.FC<OMASummaryProps> = ({
   const fileLink = useMemo(() => chartData.PackageURL, [chartData]);
   const matches = useMediaQuery('(max-width:500px)');
   const router = useRouter();
-  return (
-    <>
+
+  function StackButtons() {
+    return (
       <Stack
         spacing={2}
         direction="row"
@@ -253,6 +254,12 @@ const OMASummary: React.FC<OMASummaryProps> = ({
           PESQUISA AVANÇADA
         </Button>
       </Stack>
+    );
+  }
+
+  return (
+    <>
+      <StackButtons />
       <ThemeProvider theme={light}>
         <Grid container spacing={2}>
           <Grid item xs={12} md={20}>
@@ -646,45 +653,7 @@ const OMASummary: React.FC<OMASummaryProps> = ({
             </Paper>
           </Grid>
         </Grid>
-        <Stack
-          spacing={2}
-          direction="row"
-          {...(matches && {
-            direction: 'column',
-          })}
-          justifyContent="flex-end"
-          my={4}
-        >
-          <Button
-            variant="outlined"
-            color="info"
-            startIcon={<ArrowBackIcon />}
-            onClick={() => {
-              router.back();
-            }}
-          >
-            VOLTAR PARA EXPLORAR POR ANO
-          </Button>
-          <Button
-            variant="outlined"
-            color="info"
-            endIcon={<IosShareIcon />}
-            onClick={() => setModalIsOpen(true)}
-          >
-            COMPARTILHAR
-          </Button>
-          <Button
-            variant="outlined"
-            color="info"
-            endIcon={<CloudDownloadIcon />}
-            onClick={() => {
-              ReactGA.pageview(url.downloadURL(fileLink));
-            }}
-            href={url.downloadURL(fileLink)}
-          >
-            BAIXAR DADOS
-          </Button>
-        </Stack>
+        <StackButtons />
       </ThemeProvider>
       <ShareModal
         isOpen={modalIsOpen}


### PR DESCRIPTION
Esse PR:
* Remove a repetição de código na página de OMA na hora de exibir os botões de ação que são chamados duas vezes na página, dessa forma as alterações feitas serão refletidas nas duas vezes que os botões são chamados.

<img width="641" alt="image" src="https://user-images.githubusercontent.com/64742095/201478806-84fa2494-d821-4a04-9894-18c2dddd324c.png">

