### PR TITLE
Espaçamento padrão entre ícone e texto

### DIFF
--- a/src/components/OmaChart.tsx
+++ b/src/components/OmaChart.tsx
@@ -145,7 +145,9 @@ function ShowTipoDado(props) {
             alignItems: 'center',
           }}
         >
-          <Done color="success" />
+          <ListItemIcon>
+            <Done color="warning" />
+          </ListItemIcon>
           <span>Disponibiliza dados de {texto} sumarizados</span>
         </div>
       );


### PR DESCRIPTION
Um critério do índice de completude estava com o espaçamento errado entre o texto e o ícone
<img width="447" alt="image" src="https://user-images.githubusercontent.com/64742095/201480611-ec276a01-0d50-47f4-8344-cc305c72c2a8.png">

Esse PR: 
* Aplica o espaçamento padrão entre texto e o ícone