### PR TITLE
Removendo a repetição de código dos botões

### DIFF
--- a/src/pages/pesquisar.tsx
+++ b/src/pages/pesquisar.tsx
@@ -634,69 +634,51 @@ export default function Index({ ais }) {
                   </Box>
                 )}
               </Box>
-              <Box py={4} textAlign="right">
-                <Button
-                  sx={{ mr: 2 }}
-                  variant="outlined"
-                  color="info"
-                  endIcon={<IosShareIcon />}
-                  onClick={() => setModalIsOpen(true)}
-                >
-                  COMPARTILHAR
-                </Button>
-                <Button
-                  variant="outlined"
-                  endIcon={<CloudDownloadIcon />}
-                  disabled={!downloadAvailable}
-                  onClick={() => {
-                    ReactGA.pageview(`${process.env.API_BASE_URL}/v2/download`);
-                  }}
-                  href={`${process.env.API_BASE_URL}/v2/download${query}`}
-                  id="download-button"
-                >
-                  BAIXAR DADOS
-                </Button>
-              </Box>
               {numRowsIfAvailable > 0 && (
-                <ThemeProvider theme={light}>
-                  <Paper>
-                    <Box sx={{ width: '100%' }}>
-                      <DataGrid
-                        rows={result}
-                        columns={columns}
-                        pageSize={10}
-                        rowsPerPageOptions={[10]}
-                        disableSelectionOnClick
-                        rowHeight={35}
-                        autoHeight
-                      />
-                    </Box>
-                  </Paper>
-                </ThemeProvider>
+                <>
+                  <Box py={4} textAlign="right">
+                    <Button
+                      sx={{ mr: 2 }}
+                      variant="outlined"
+                      color="info"
+                      endIcon={<IosShareIcon />}
+                      onClick={() => setModalIsOpen(true)}
+                    >
+                      COMPARTILHAR
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      endIcon={<CloudDownloadIcon />}
+                      disabled={!downloadAvailable}
+                      onClick={() => {
+                        ReactGA.pageview(
+                          `${process.env.API_BASE_URL}/v2/download`,
+                        );
+                      }}
+                      href={`${process.env.API_BASE_URL}/v2/download${query}`}
+                      id="download-button"
+                    >
+                      BAIXAR DADOS
+                    </Button>
+                  </Box>
+
+                  <ThemeProvider theme={light}>
+                    <Paper>
+                      <Box sx={{ width: '100%' }}>
+                        <DataGrid
+                          rows={result}
+                          columns={columns}
+                          pageSize={10}
+                          rowsPerPageOptions={[10]}
+                          disableSelectionOnClick
+                          rowHeight={35}
+                          autoHeight
+                        />
+                      </Box>
+                    </Paper>
+                  </ThemeProvider>
+                </>
               )}
-              <Box py={4} textAlign="right">
-                <Button
-                  sx={{ mr: 2 }}
-                  variant="outlined"
-                  color="info"
-                  endIcon={<IosShareIcon />}
-                  onClick={() => setModalIsOpen(true)}
-                >
-                  COMPARTILHAR
-                </Button>
-                <Button
-                  variant="outlined"
-                  endIcon={<CloudDownloadIcon />}
-                  disabled={!downloadAvailable}
-                  onClick={() => {
-                    ReactGA.pageview(`${process.env.API_BASE_URL}/v2/download`);
-                  }}
-                  href={`${process.env.API_BASE_URL}/v2/download${query}`}
-                  id="download-button"
-                >
-                  BAIXAR DADOS
-                </Button>
-              </Box>
             </Box>
           )}
         </Box>

--- a/src/pages/pesquisar.tsx
+++ b/src/pages/pesquisar.tsx
@@ -633,51 +633,49 @@ export default function Index({ ais }) {
                     )}
                   </Box>
                 )}
+
+                <Box py={4} textAlign="right">
+                  <Button
+                    sx={{ mr: 2 }}
+                    variant="outlined"
+                    color="info"
+                    endIcon={<IosShareIcon />}
+                    onClick={() => setModalIsOpen(true)}
+                  >
+                    COMPARTILHAR
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    endIcon={<CloudDownloadIcon />}
+                    disabled={!downloadAvailable}
+                    onClick={() => {
+                      ReactGA.pageview(
+                        `${process.env.API_BASE_URL}/v2/download`,
+                      );
+                    }}
+                    href={`${process.env.API_BASE_URL}/v2/download${query}`}
+                    id="download-button"
+                  >
+                    BAIXAR DADOS
+                  </Button>
+                </Box>
               </Box>
               {numRowsIfAvailable > 0 && (
-                <>
-                  <Box py={4} textAlign="right">
-                    <Button
-                      sx={{ mr: 2 }}
-                      variant="outlined"
-                      color="info"
-                      endIcon={<IosShareIcon />}
-                      onClick={() => setModalIsOpen(true)}
-                    >
-                      COMPARTILHAR
-                    </Button>
-                    <Button
-                      variant="outlined"
-                      endIcon={<CloudDownloadIcon />}
-                      disabled={!downloadAvailable}
-                      onClick={() => {
-                        ReactGA.pageview(
-                          `${process.env.API_BASE_URL}/v2/download`,
-                        );
-                      }}
-                      href={`${process.env.API_BASE_URL}/v2/download${query}`}
-                      id="download-button"
-                    >
-                      BAIXAR DADOS
-                    </Button>
-                  </Box>
-
-                  <ThemeProvider theme={light}>
-                    <Paper>
-                      <Box sx={{ width: '100%' }}>
-                        <DataGrid
-                          rows={result}
-                          columns={columns}
-                          pageSize={10}
-                          rowsPerPageOptions={[10]}
-                          disableSelectionOnClick
-                          rowHeight={35}
-                          autoHeight
-                        />
-                      </Box>
-                    </Paper>
-                  </ThemeProvider>
-                </>
+                <ThemeProvider theme={light}>
+                  <Paper>
+                    <Box sx={{ width: '100%' }}>
+                      <DataGrid
+                        rows={result}
+                        columns={columns}
+                        pageSize={10}
+                        rowsPerPageOptions={[10]}
+                        disableSelectionOnClick
+                        rowHeight={35}
+                        autoHeight
+                      />
+                    </Box>
+                  </Paper>
+                </ThemeProvider>
               )}
             </Box>
           )}


### PR DESCRIPTION
Esse PR:
* Remove a repetição dos botões de compartilhar de baixar dados da página de pesquisa.
![image](https://user-images.githubusercontent.com/64742095/202263376-1b3a9f8c-e4c6-41f4-a6c6-af27b9950ce4.png)
> A repetição não é necessária, haja visto que o conteúdo da tabela não é extenso o suficiente para justificar essa repetição.
