### PR TITLE
Erro na URL da página de pesquisa

### DIFF
--- a/src/pages/pesquisar.tsx
+++ b/src/pages/pesquisar.tsx
@@ -353,6 +353,9 @@ export default function Index({ ais }) {
         });
         setSelectedAgencies(orgaosSelecionados);
         return orgaosSelecionados;
+
+      default:
+        break;
     }
   }
 
@@ -363,6 +366,8 @@ export default function Index({ ais }) {
     getUrlParameter('orgaos');
 
     location.search != '' && firstRequest();
+
+    insertUrlParam('anos', selectedYears);
   }, []);
 
   interface AgencyOptionType {


### PR DESCRIPTION
Esse PR:
* Faz com que a URL na página de pesquisa já comece com o parâmetro "anos" tendo o valor do ano atual, corrigindo o erro de quando o usuário tenta compartilhar a URL sem modificar o ano, a pesquisa vai para o ano de 2018 mesmo o ano estando marcado como 2022 no select.