### PR TITLE
Texto invisível na página de equipe

### DIFF
--- a/src/pages/equipe.tsx
+++ b/src/pages/equipe.tsx
@@ -172,7 +172,7 @@ export default function Team() {
           </Grid>
         </Container>
       </Box>
-      <Box py={12} sx={{ bgcolor: 'primary.main' }}>
+      <Box py={12}>
         <Container fixed>
           <Grid container spacing={2}>
             <Grid item md={6}>


### PR DESCRIPTION
Esse PR:
* Resolve o problema de texto e botão invisível na página de equipe reportado por @rdurl0 
![image](https://user-images.githubusercontent.com/64742095/209137874-47d9b3b4-fda6-42e5-b04d-b6a47606a697.png)

