### PR TITLE
Coluna sem dados

### DIFF
--- a/src/components/RemunerationBarGraph.tsx
+++ b/src/components/RemunerationBarGraph.tsx
@@ -60,7 +60,9 @@ const RemunerationBarGraph: React.FC<RemunerationBarGraphProps> = ({
         )
         .reverse()[0];
       // 10000 is used here as the min value of chart height
-      return found ? found.BaseRemuneration + found.OtherRemunerations : 10000;
+      return found
+        ? found.BaseRemuneration + found.OtherRemunerations + 1
+        : 10000;
     }
     return 10000;
   }, [data]);


### PR DESCRIPTION
Esse PR:
* Corrige o erro em que os TREs tinham a maior barra de remunerações constando como "Sem dados".
![image](https://user-images.githubusercontent.com/64742095/209347108-c67ed596-3608-421b-b55c-6f99be0313d2.png)
> (Mesmo tendo dados de benefícios a legenda aparecia sem dados).
Isso se dava pelo fato do formatador das legendas não estar preparado para receber órgãos que tivessem só uma modalidade de remuneração (apenas benefícios e zero de salário ou vice-versa).

Tecnicamente quando não há dados para determinado mês a barra desse mês não deveria crescer, mas como a nossa intenção é chamar a atenção do usuário para essa falta de dados e usamos até uma cor diferente nessa barra, é necessário calcular o tamanho da barra de "sem dados" baseado nos dados de outro mês, no nosso caso o mês com maior registro de remunerações está sendo usado para esse cálculo. Por isso o problema sempre ocorria no mês que tinha o maior registro de remunerações. 

Resultado com a correção:
![image](https://user-images.githubusercontent.com/64742095/209348693-5ec01d07-2a69-41db-8f33-6fe847c241ba.png)
![image](https://user-images.githubusercontent.com/64742095/209348962-226d3727-cd0b-4561-9036-5babe2c9e06c.png)

@duardoqueiroz @Joellensilva 
