### PR TITLE
Disposição botões OMA

### DIFF
--- a/src/components/AgencyWithNavigation.tsx
+++ b/src/components/AgencyWithNavigation.tsx
@@ -151,7 +151,7 @@ const AgencyPageWithNavigation: React.FC<AgencyPageWithNavigationProps> = ({
                   <Button
                     variant="outlined"
                     color="info"
-                    startIcon={<SearchIcon />}
+                    endIcon={<SearchIcon />}
                     onClick={() => {
                       router.push(
                         `/pesquisar?anos=${year}&orgaos=${agency.aid}`,

--- a/src/components/AgencyWithNavigation.tsx
+++ b/src/components/AgencyWithNavigation.tsx
@@ -203,15 +203,7 @@ const AgencyPageWithNavigation: React.FC<AgencyPageWithNavigationProps> = ({
                 <Button
                   variant="outlined"
                   color="info"
-                  endIcon={<ArrowForwardIosIcon />}
-                  href={`/orgao/${id}/${year}/${selectedMonth}`}
-                >
-                  EXPLORAR
-                </Button>
-                <Button
-                  variant="outlined"
-                  color="info"
-                  startIcon={<SearchIcon />}
+                  endIcon={<SearchIcon />}
                   onClick={() => {
                     router.push(`/pesquisar?anos=${year}&orgaos=${agency.aid}`);
                   }}

--- a/src/components/OmaChart.tsx
+++ b/src/components/OmaChart.tsx
@@ -199,69 +199,122 @@ const OMASummary: React.FC<OMASummaryProps> = ({
 }) => {
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const fileLink = `${process.env.S3_REPO_URL}/${agency}/datapackage/${agency}-${year}-${month}.zip`;
-  const matches = useMediaQuery('(max-width:500px)');
+  const matches = useMediaQuery('(max-width:900px)');
   const router = useRouter();
-
-  function StackButtons() {
-    return (
-      <Stack
-        spacing={2}
-        direction="row"
-        {...(matches && {
-          direction: 'column',
-        })}
-        justifyContent="flex-end"
-        mt={2}
-        mb={4}
-      >
-        <Button
-          variant="outlined"
-          color="info"
-          startIcon={<ArrowBackIcon />}
-          onClick={() => {
-            router.back();
-          }}
-        >
-          VOLTAR PARA EXPLORAR POR ANO
-        </Button>
-        <Button
-          variant="outlined"
-          color="info"
-          endIcon={<IosShareIcon />}
-          onClick={() => setModalIsOpen(true)}
-        >
-          COMPARTILHAR
-        </Button>
-        <Button
-          variant="outlined"
-          color="info"
-          endIcon={<CloudDownloadIcon />}
-          onClick={() => {
-            ReactGA.pageview(url.downloadURL(fileLink));
-          }}
-          href={url.downloadURL(fileLink)}
-        >
-          BAIXAR DADOS
-        </Button>
-        <Button
-          variant="outlined"
-          color="info"
-          startIcon={<SearchIcon />}
-          onClick={() => {
-            router.push(
-              `/pesquisar?anos=${year}&meses=${month}&orgaos=${agency}`,
-            );
-          }}
-        >
-          PESQUISA AVANÇADA
-        </Button>
-      </Stack>
-    );
-  }
 
   return (
     <>
-      <StackButtons />
+      {!matches ? (
+        <ButtonBox>
+          <Stack
+            spacing={2}
+            direction="row"
+            justifyContent="flex-start"
+            mt={2}
+            mb={4}
+          >
+            <Button
+              variant="outlined"
+              color="info"
+              startIcon={<ArrowBackIcon />}
+              onClick={() => {
+                router.back();
+              }}
+            >
+              VOLTAR
+            </Button>
+          </Stack>
+          <Stack
+            spacing={2}
+            direction="row"
+            justifyContent="flex-end"
+            mt={2}
+            mb={4}
+          >
+            <Button
+              variant="outlined"
+              color="info"
+              endIcon={<IosShareIcon />}
+              onClick={() => setModalIsOpen(true)}
+            >
+              COMPARTILHAR
+            </Button>
+            <Button
+              variant="outlined"
+              color="info"
+              endIcon={<CloudDownloadIcon />}
+              onClick={() => {
+                ReactGA.pageview(url.downloadURL(fileLink));
+              }}
+              href={url.downloadURL(fileLink)}
+            >
+              BAIXAR
+            </Button>
+            <Button
+              variant="outlined"
+              color="info"
+              endIcon={<SearchIcon />}
+              onClick={() => {
+                router.push(
+                  `/pesquisar?anos=${year}&meses=${month}&orgaos=${agency}`,
+                );
+              }}
+            >
+              PESQUISAR
+            </Button>
+          </Stack>
+        </ButtonBox>
+      ) : (
+        <Stack
+          spacing={2}
+          direction="column"
+          justifyContent="center"
+          mt={2}
+          mb={4}
+        >
+          <Button
+            variant="outlined"
+            color="info"
+            startIcon={<ArrowBackIcon />}
+            onClick={() => {
+              router.back();
+            }}
+          >
+            VOLTAR PARA EXPLORAR POR ANO
+          </Button>
+          <Button
+            variant="outlined"
+            color="info"
+            endIcon={<IosShareIcon />}
+            onClick={() => setModalIsOpen(true)}
+          >
+            COMPARTILHAR
+          </Button>
+          <Button
+            variant="outlined"
+            color="info"
+            endIcon={<CloudDownloadIcon />}
+            onClick={() => {
+              ReactGA.pageview(url.downloadURL(fileLink));
+            }}
+            href={url.downloadURL(fileLink)}
+          >
+            BAIXAR DADOS
+          </Button>
+          <Button
+            variant="outlined"
+            color="info"
+            startIcon={<SearchIcon />}
+            onClick={() => {
+              router.push(
+                `/pesquisar?anos=${year}&meses=${month}&orgaos=${agency}`,
+              );
+            }}
+          >
+            PESQUISA AVANÇADA
+          </Button>
+        </Stack>
+      )}
       <ThemeProvider theme={light}>
         <Grid container spacing={2}>
           <Grid item xs={12} md={20}>
@@ -655,7 +708,117 @@ const OMASummary: React.FC<OMASummaryProps> = ({
             </Paper>
           </Grid>
         </Grid>
-        <StackButtons />
+        {!matches ? (
+          <ButtonBox>
+            <Stack
+              spacing={2}
+              direction="row"
+              justifyContent="flex-start"
+              mt={2}
+              mb={4}
+            >
+              <Button
+                variant="outlined"
+                color="info"
+                startIcon={<ArrowBackIcon />}
+                onClick={() => {
+                  router.back();
+                }}
+              >
+                VOLTAR
+              </Button>
+            </Stack>
+            <Stack
+              spacing={2}
+              direction="row"
+              justifyContent="flex-end"
+              mt={2}
+              mb={4}
+            >
+              <Button
+                variant="outlined"
+                color="info"
+                endIcon={<IosShareIcon />}
+                onClick={() => setModalIsOpen(true)}
+              >
+                COMPARTILHAR
+              </Button>
+              <Button
+                variant="outlined"
+                color="info"
+                endIcon={<CloudDownloadIcon />}
+                onClick={() => {
+                  ReactGA.pageview(url.downloadURL(fileLink));
+                }}
+                href={url.downloadURL(fileLink)}
+              >
+                BAIXAR
+              </Button>
+              <Button
+                variant="outlined"
+                color="info"
+                endIcon={<SearchIcon />}
+                onClick={() => {
+                  router.push(
+                    `/pesquisar?anos=${year}&meses=${month}&orgaos=${agency}`,
+                  );
+                }}
+              >
+                PESQUISAR
+              </Button>
+            </Stack>
+          </ButtonBox>
+        ) : (
+          <Stack
+            spacing={2}
+            direction="column"
+            justifyContent="center"
+            mt={2}
+            mb={4}
+          >
+            <Button
+              variant="outlined"
+              color="info"
+              startIcon={<ArrowBackIcon />}
+              onClick={() => {
+                router.back();
+              }}
+            >
+              VOLTAR PARA EXPLORAR POR ANO
+            </Button>
+            <Button
+              variant="outlined"
+              color="info"
+              endIcon={<IosShareIcon />}
+              onClick={() => setModalIsOpen(true)}
+            >
+              COMPARTILHAR
+            </Button>
+            <Button
+              variant="outlined"
+              color="info"
+              endIcon={<CloudDownloadIcon />}
+              onClick={() => {
+                ReactGA.pageview(url.downloadURL(fileLink));
+              }}
+              href={url.downloadURL(fileLink)}
+            >
+              BAIXAR DADOS
+            </Button>
+            <Button
+              variant="outlined"
+              color="info"
+              startIcon={<SearchIcon />}
+              onClick={() => {
+                router.push(
+                  `/pesquisar?anos=${year}&meses=${month}&orgaos=${agency}`,
+                );
+              }}
+            >
+              PESQUISA AVANÇADA
+            </Button>
+          </Stack>
+        )}
       </ThemeProvider>
       <ShareModal
         url={`https://dadosjusbr.org/orgao/${agency}/${year}/${month}`}
@@ -689,6 +852,11 @@ const Div = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+`;
+
+const ButtonBox = styled.div`
+  display: flex;
+  justify-content: space-between;
 `;
 
 export default OMASummary;

--- a/src/components/OmaChart.tsx
+++ b/src/components/OmaChart.tsx
@@ -280,7 +280,7 @@ const OMASummary: React.FC<OMASummaryProps> = ({
               router.back();
             }}
           >
-            VOLTAR PARA EXPLORAR POR ANO
+            VOLTAR
           </Button>
           <Button
             variant="outlined"
@@ -299,19 +299,19 @@ const OMASummary: React.FC<OMASummaryProps> = ({
             }}
             href={url.downloadURL(fileLink)}
           >
-            BAIXAR DADOS
+            BAIXAR
           </Button>
           <Button
             variant="outlined"
             color="info"
-            startIcon={<SearchIcon />}
+            endIcon={<SearchIcon />}
             onClick={() => {
               router.push(
                 `/pesquisar?anos=${year}&meses=${month}&orgaos=${agency}`,
               );
             }}
           >
-            PESQUISA AVANÇADA
+            PESQUISAR
           </Button>
         </Stack>
       )}
@@ -784,7 +784,7 @@ const OMASummary: React.FC<OMASummaryProps> = ({
                 router.back();
               }}
             >
-              VOLTAR PARA EXPLORAR POR ANO
+              VOLTAR
             </Button>
             <Button
               variant="outlined"
@@ -803,19 +803,19 @@ const OMASummary: React.FC<OMASummaryProps> = ({
               }}
               href={url.downloadURL(fileLink)}
             >
-              BAIXAR DADOS
+              BAIXAR
             </Button>
             <Button
               variant="outlined"
               color="info"
-              startIcon={<SearchIcon />}
+              endIcon={<SearchIcon />}
               onClick={() => {
                 router.push(
                   `/pesquisar?anos=${year}&meses=${month}&orgaos=${agency}`,
                 );
               }}
             >
-              PESQUISA AVANÇADA
+              PESQUISAR
             </Button>
           </Stack>
         )}

--- a/src/components/RemunerationBarGraph.tsx
+++ b/src/components/RemunerationBarGraph.tsx
@@ -288,7 +288,7 @@ const RemunerationBarGraph: React.FC<RemunerationBarGraphProps> = ({
                 Total de remunerações de membros por mês em {year}
               </Typography>
               {agency && (
-                <Grid display="flex" justifyContent="flex-end">
+                <Grid display="flex" justifyContent="flex-end" sx={{ mt: 3 }}>
                   <Button
                     variant="outlined"
                     color="secondary"


### PR DESCRIPTION
Esse PR: 
* Padroniza os botões da página OMA com as alterações feitas na página de explorar por ano
* FIX #97

Antes:
![image](https://user-images.githubusercontent.com/64742095/211814805-3cb12fbc-55b5-4f11-aa1b-69eb8d6f9ede.png)

 Depois:
![image](https://user-images.githubusercontent.com/64742095/211813717-6cc37924-fec1-4f48-ab0e-4bc77bd96050.png)
