### PR TITLE
Formatando a string de compartilhamento e o nome da página

### DIFF
--- a/src/components/DropDownGroupSelector.tsx
+++ b/src/components/DropDownGroupSelector.tsx
@@ -77,7 +77,7 @@ const DropDownGroupSelector: React.FC<DropDownGroupSelectorProps> = ({
 
 export default DropDownGroupSelector;
 
-function formatToAgency(agency: string) {
+export function formatToAgency(agency: string) {
   if (agency === '') {
     return '';
   }
@@ -89,9 +89,17 @@ function formatToAgency(agency: string) {
     return newString.join('');
   });
   const a = formatedSubs.join(' ');
-  return a.includes('Justica')
+  const final = a.includes('Justica')
     ? a.replace('Justica', 'Justiça')
     : a.includes('Ministerios Publicos')
     ? a.replace('Ministerios Publicos', 'Ministérios Públicos')
     : a;
+
+  return final.split(' ').length > 2
+    ? final.split(' ')[0] +
+        ' ' +
+        final.split(' ')[1].toLowerCase() +
+        ' ' +
+        final.split(' ')[2]
+    : final;
 }

--- a/src/pages/grupo/[summary].tsx
+++ b/src/pages/grupo/[summary].tsx
@@ -21,9 +21,10 @@ import api from '../../services/api';
 import DropDownGroupSelector from '../../components/DropDownGroupSelector';
 import AgencyWithNavigation from '../../components/AgencyWithNavigation';
 import { getCurrentYear } from '../../functions/currentYear';
+import { formatToAgency } from '../../components/DropDownGroupSelector';
 // this constant is used to placehold the max value of a chart data
 export default function SummaryPage({ dataList, summary }) {
-  const pageTitle = `Dados/${summary}`;
+  const pageTitle = `${formatToAgency(summary)}`;
   const [value, setValue] = useState('');
   return (
     <Page>
@@ -32,7 +33,7 @@ export default function SummaryPage({ dataList, summary }) {
         <meta property="og:image" content="/img/icon_dadosjus_background.png" />
         <meta
           property="og:title"
-          content={`Veja os dados do estado: ${summary}`}
+          content={`Veja os dados sobre ${formatToAgency(summary)}`}
         />
         <meta
           property="og:description"
@@ -54,9 +55,7 @@ export default function SummaryPage({ dataList, summary }) {
             <DropDownGroupSelector value={summary} />
           </Grid>
           <Grid item pb={4}>
-            <Typography>
-              Selecione o órgão
-            </Typography>
+            <Typography>Selecione o órgão</Typography>
 
             <FormControl fullWidth sx={{ m: 1, minWidth: 240, maxWidth: 250 }}>
               <Select


### PR DESCRIPTION
Esse PR:
* FIX #305 
* Formata o nome da página deixando apenas o tipo do órgão (quando o usuário está na página sobre Conselhos de Justiça o noma da página será "Conselhos de Justiça");
* Formata a string de compartilhamento para o seguinte padrão: "Veja os dados sobre {sumarry}", onde {sumarry} representa o tipo de órgão. Sendo assim ao compartilhar a página de Justiça Estadual aparecerá "Veja os dados sobre Justiça Federal".