### PR TITLE
Filtrando os órgãos na página de status

### DIFF
--- a/src/pages/status.tsx
+++ b/src/pages/status.tsx
@@ -18,7 +18,7 @@ import { formatAgency } from '../functions/format';
 
 export default function Index({ ais }) {
   const collecting = ais
-    .filter(ag => ag.collecting === null)
+    .filter(ag => ag.collecting === undefined)
     .sort((a, b) => {
       if (a.uf > b.uf) {
         return 1;
@@ -29,7 +29,7 @@ export default function Index({ ais }) {
       return 0;
     });
   const notCollecting = ais
-    .filter(ag => ag.collecting !== null)
+    .filter(ag => ag.collecting !== undefined)
     .sort((a, b) => {
       if (a.uf > b.uf) {
         return 1;


### PR DESCRIPTION
Percebi que a página de status está filtrando os órgãos de forma incorreta (o que é estranho, já o que essa página não é modificada há uns 3 meses).
![image](https://user-images.githubusercontent.com/64742095/219100862-628f8b50-5620-4f79-b665-84f191d8c999.png)

Esse PR:
* Filtra os órgãos coletado e não coletado de forma correta