### PR TITLE
OMA pagina não encontrada

### DIFF
--- a/src/components/MonthPopover.tsx
+++ b/src/components/MonthPopover.tsx
@@ -57,6 +57,7 @@ export default function MonthPopover({ children, agency, year }) {
         <Typography sx={{ p: 2 }}>
           {list.map(month => (
             <Typography
+              key={month}
               sx={{
                 width: 145,
                 cursor: 'pointer',

--- a/src/pages/orgao/[agency]/[year]/[month].tsx
+++ b/src/pages/orgao/[agency]/[year]/[month].tsx
@@ -180,10 +180,9 @@ export default function OmaPage({
                     alignItems: 'center',
                   }}
                 >
-                  <div>
-                    <CircularProgress color="info" />
-                  </div>
-                  <p>Não há dados para esse mês</p>
+                  <Typography variant="h6">
+                    Não há dados para esse mês
+                  </Typography>
                 </Box>
               ) : (
                 oma.crawlingTime && (
@@ -260,12 +259,24 @@ export const getServerSideProps: GetServerSideProps = async context => {
     };
   }
 
+  if (month > 12 || month < 1) {
+    return {
+      redirect: {
+        destination: '/404',
+      },
+      props: {},
+    };
+  }
+
   let mi = [];
-  const { data: d3 } = await api.default.get(
-    `/dados/${agency}/${year}/${month}`,
-  );
-  if (d3) {
+  try {
+    const { data: d3 } = await api.default.get(
+      `/dados/${agency}/${year}/${month}`,
+    );
+
     mi = d3.at(0);
+  } catch (err) {
+    mi = [];
   }
 
   try {


### PR DESCRIPTION
Esse PR: 
* Resolve o erro de página não encontrada reportado no slack

Já havia uma interface para quando o usuário tentava acessar um mês ainda não coletado, porém a verificação que levava à essa interface era falha.

Antes:
![image](https://user-images.githubusercontent.com/64742095/224875045-66b9ca10-4bb9-435c-a171-670118de8e30.png)

Depois:
![image](https://user-images.githubusercontent.com/64742095/224875586-6cfd66de-578e-42cd-9051-899787807d8f.png)
<em>(verificação de coleta realizada funcionando)</em>