### PR TITLE
Comportamento aviso ano

### DIFF
--- a/src/components/AlertModal.tsx
+++ b/src/components/AlertModal.tsx
@@ -1,0 +1,88 @@
+import {
+  Alert,
+  Backdrop,
+  Box,
+  Button,
+  Fade,
+  Modal,
+  Typography,
+} from '@mui/material';
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+
+const AlertModal = ({
+  agencyData,
+  openParam,
+  handleOpen,
+  handleClose,
+  children,
+}) => {
+  const style = {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    width: 400,
+    bgcolor: '#3e5363',
+    border: '1px solid white',
+    borderRadius: 2,
+    boxShadow: 24,
+    p: 4,
+  };
+
+  return (
+    <>
+      <Alert
+        severity="warning"
+        variant="outlined"
+        sx={{
+          alignItems: 'center',
+          width: 'fit-content',
+          cursor: 'pointer',
+        }}
+        onClick={() => handleOpen()}
+      >
+        {children} <u>Ajude-nos a abrir os dados.</u>
+      </Alert>
+      <Modal
+        aria-labelledby="transition-modal-title"
+        aria-describedby="transition-modal-description"
+        open={openParam}
+        onClose={handleClose}
+        closeAfterTransition
+        BackdropComponent={Backdrop}
+        BackdropProps={{
+          timeout: 800,
+        }}
+      >
+        <Fade in={openParam}>
+          <Box sx={style}>
+            <Typography id="transition-modal-title" variant="h6" component="h2">
+              Ajude na inclusão de dados do {agencyData?.nome}
+            </Typography>
+            <Typography
+              id="transition-modal-description"
+              sx={{ mt: 2, textAlign: 'justify' }}
+            >
+              Este órgão não conta com todos os dados de remunerações. Você pode
+              ajudar o DadosJusBr fazendo um requerimento na ouvidoria deste
+              órgão solicitando a publicação recorrente de todos gastos.
+            </Typography>
+            <Box display="flex" justifyContent="center" mt={2}>
+              <Button
+                variant="outlined"
+                color="info"
+                href={agencyData?.ouvidoria}
+                target="_blank"
+                endIcon={<ArrowForwardIosIcon />}
+              >
+                Ir para a ouvidoria
+              </Button>
+            </Box>
+          </Box>
+        </Fade>
+      </Modal>
+    </>
+  );
+};
+
+export default AlertModal;

--- a/src/components/RemunerationBarGraph.tsx
+++ b/src/components/RemunerationBarGraph.tsx
@@ -24,6 +24,7 @@ import MONTHS from '../@types/MONTHS';
 import CrawlingDateTable from './CrawlingDateTable';
 import NotCollecting from './NotCollecting';
 import { getCurrentYear } from '../functions/currentYear';
+import AlertModal from './AlertModal';
 
 const Chart = dynamic(() => import('react-apexcharts'), { ssr: false });
 
@@ -48,6 +49,9 @@ const RemunerationBarGraph: React.FC<RemunerationBarGraphProps> = ({
   billion = false,
   selectedMonth,
 }) => {
+  const [open, setOpen] = useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
   // this constant is used as an alx value to determine the max graph height
   const MaxMonthPlaceholder = useMemo(() => {
     if (data) {
@@ -305,19 +309,17 @@ const RemunerationBarGraph: React.FC<RemunerationBarGraphProps> = ({
               data.length > 0 &&
               monthsWithouData.length > 0 ? (
                 <Box display="flex" justifyContent="center">
-                  <Alert
-                    severity="warning"
-                    variant="outlined"
-                    sx={{
-                      alignItems: 'center',
-                      width: 'fit-content',
-                    }}
+                  <AlertModal
+                    agencyData={agency}
+                    openParam={open}
+                    handleClose={handleClose}
+                    handleOpen={handleOpen}
                   >
                     Este órgão não publicou dados de{' '}
                     {`${monthsWithouData.length} ${
                       monthsWithouData.length > 1 ? 'meses.' : 'mês.'
                     }`}{' '}
-                  </Alert>
+                  </AlertModal>
                 </Box>
               ) : null}
               <Typography mt={2} variant="h6" textAlign="center">


### PR DESCRIPTION
Esse PR:
* Unifica o comportamento do aviso de meses faltantes na página de ano e na página de mês
* Muda o texto do botão convidando o usuário a abrir os dados e utiliza o sublinhado para mostrar que é clicável como os <a href="#">links</a>

Resultado:
![image](https://user-images.githubusercontent.com/64742095/230401569-0e154ec0-a34f-4ba9-a9e3-a4eb98f22af5.png)

Há a opção de deixar mais parecido com um link, mas não achei tão interessante:
![image](https://user-images.githubusercontent.com/64742095/230401763-273182c3-02e9-4499-84e1-9c5de495bafe.png)
