### PR TITLE
Formatação de siglas e membros ativos

### DIFF
--- a/src/components/Common/DropDownGroupSelector/index.tsx
+++ b/src/components/Common/DropDownGroupSelector/index.tsx
@@ -11,12 +11,11 @@ import {
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 
-import STATE_AGENCIES from '../../../@types/STATE_AGENCIES';
 import { formatToAgency } from '../../../functions/format';
 
 export interface DropDownGroupSelectorProps
   extends Omit<HTMLAttributes<HTMLSelectElement>, 'onChange'> {
-  value?: STATE_AGENCIES;
+  value?: string;
   noStyle?: boolean;
   inputType?: 'outlined' | 'standard' | 'filled';
   minWidth?: number;

--- a/src/components/OmaChart/components/AgencyGenerals.tsx
+++ b/src/components/OmaChart/components/AgencyGenerals.tsx
@@ -44,7 +44,7 @@ const index = ({
     <Paper elevation={0}>
       <Box p={2} pb={0} textAlign="center">
         <Typography variant="h6">
-          Resumo de remunerações de membros ativos
+          Resumo de remunerações de membros {/* ativo */}
           <Tooltip
             placement="bottom"
             title={
@@ -65,8 +65,8 @@ const index = ({
                 funcionário de acordo com a lei, como imposto de renda,
                 contribuição para previdência, pensão alimentícia, entre outros.
                 <hr />
-                <b>Membros:</b> Participantes ativos do órgao, incluindo os
-                servidores públicos, os militares e os membros do Poder
+                <b>Membros:</b> Participantes {/* ativos */} do órgao, incluindo
+                os servidores públicos, os militares e os membros do Poder
                 Judiciário.
                 <hr />
                 <b>Servidor:</b> Funcionário público que exerce cargo ou função

--- a/src/components/OmaChart/components/AgencyGenerals.tsx
+++ b/src/components/OmaChart/components/AgencyGenerals.tsx
@@ -44,7 +44,7 @@ const index = ({
     <Paper elevation={0}>
       <Box p={2} pb={0} textAlign="center">
         <Typography variant="h6">
-          Resumo de remunerações de membros {/* ativo */}
+          Resumo de remunerações de membros
           <Tooltip
             placement="bottom"
             title={

--- a/src/components/OmaChart/components/AgencyGenerals.tsx
+++ b/src/components/OmaChart/components/AgencyGenerals.tsx
@@ -65,9 +65,8 @@ const index = ({
                 funcionário de acordo com a lei, como imposto de renda,
                 contribuição para previdência, pensão alimentícia, entre outros.
                 <hr />
-                <b>Membros:</b> Participantes {/* ativos */} do órgao, incluindo
-                os servidores públicos, os militares e os membros do Poder
-                Judiciário.
+                <b>Membros:</b> Participantes do órgao, incluindo os servidores
+                públicos, os militares e os membros do Poder Judiciário.
                 <hr />
                 <b>Servidor:</b> Funcionário público que exerce cargo ou função
                 pública, com vínculo empregatício, e que recebe remuneração fixa

--- a/src/components/OmaChart/components/MembersGraph.tsx
+++ b/src/components/OmaChart/components/MembersGraph.tsx
@@ -9,7 +9,7 @@ const index = ({ chartData }: { chartData: AgencyRemuneration }) => (
     <Paper elevation={0}>
       <Box pt={4} py={4} px={2}>
         <Typography variant="h6" textAlign="center">
-          Distribuição de remunerações de membros {/* ativos */}
+          Distribuição de remunerações de membros
         </Typography>
         <Box px={2}>
           {!chartData.histograma ? (

--- a/src/components/OmaChart/components/MembersGraph.tsx
+++ b/src/components/OmaChart/components/MembersGraph.tsx
@@ -9,7 +9,7 @@ const index = ({ chartData }: { chartData: AgencyRemuneration }) => (
     <Paper elevation={0}>
       <Box pt={4} py={4} px={2}>
         <Typography variant="h6" textAlign="center">
-          Distribuição de remunerações de membros ativos
+          Distribuição de remunerações de membros {/* ativos */}
         </Typography>
         <Box px={2}>
           {!chartData.histograma ? (

--- a/src/components/RemunerationChartLegend/index.tsx
+++ b/src/components/RemunerationChartLegend/index.tsx
@@ -127,8 +127,8 @@ const index = ({
                 funcionário de acordo com a lei, como imposto de renda,
                 contribuição para previdência, pensão alimentícia, entre outros.
                 <hr />
-                <b>Membros:</b> Participantes ativos do órgao, incluindo os
-                servidores públicos, os militares e os membros do Poder
+                <b>Membros:</b> Participantes {/* ativos */} do órgao, incluindo
+                os servidores públicos, os militares e os membros do Poder
                 Judiciário.
                 <hr />
                 <b>Servidor:</b> Funcionário público que exerce cargo ou função

--- a/src/components/RemunerationChartLegend/index.tsx
+++ b/src/components/RemunerationChartLegend/index.tsx
@@ -127,9 +127,8 @@ const index = ({
                 funcionário de acordo com a lei, como imposto de renda,
                 contribuição para previdência, pensão alimentícia, entre outros.
                 <hr />
-                <b>Membros:</b> Participantes {/* ativos */} do órgao, incluindo
-                os servidores públicos, os militares e os membros do Poder
-                Judiciário.
+                <b>Membros:</b> Participantes do órgao, incluindo os servidores
+                públicos, os militares e os membros do Poder Judiciário.
                 <hr />
                 <b>Servidor:</b> Funcionário público que exerce cargo ou função
                 pública, com vínculo empregatício, e que recebe remuneração fixa

--- a/src/functions/format.ts
+++ b/src/functions/format.ts
@@ -1,14 +1,23 @@
 function formatAgency(aid: string): string {
+  const strNumbers = extractNumbers(aid);
+
   if (aid.toLowerCase() === 'tjdft' || aid.toLowerCase() === 'mpdft')
     return `${aid.substring(0, 2)}-${aid.substring(2, 5)}`;
-  if (
-    aid.toLowerCase().startsWith('trt') ||
-    aid.toLowerCase().startsWith('trf')
-  )
-    return aid;
-  if (aid.length === 4) return `${aid.substring(0, 2)}-${aid.substring(2, 4)}`;
-  if (aid.length === 5) return `${aid.substring(0, 3)}-${aid.substring(3, 5)}`;
+
+  if (strNumbers > 0) return `${aid.replace(/\d+/g, '')}-${strNumbers}`;
+
+  if (aid.length > 3)
+    return `${aid.substring(0, aid.length - 2)}-${aid.substring(
+      aid.length - 2,
+      aid.length,
+    )}`;
+
   return aid;
+}
+
+function extractNumbers(str: string): number {
+  const matches = str.match(/\d+$/);
+  return matches ? parseInt(matches[0], 10) : -1;
 }
 
 function formatToAgency(input: string): string {
@@ -42,4 +51,11 @@ const formatBytes = (bytes: number, decimals = 2) => {
 
   return `${parseFloat((bytes / 1024 ** i).toFixed(dm))} ${sizes[i]}`;
 };
-export { formatAgency, formatToAgency, formatCurrencyValue, formatBytes };
+
+export {
+  formatAgency,
+  extractNumbers,
+  formatToAgency,
+  formatCurrencyValue,
+  formatBytes,
+};

--- a/src/pages/grupo/[summary].tsx
+++ b/src/pages/grupo/[summary].tsx
@@ -23,9 +23,32 @@ import DropDownGroupSelector from '../../components/Common/DropDownGroupSelector
 import { getCurrentYear } from '../../functions/currentYear';
 import AgencyWithoutNavigation from '../../components/AnnualRemunerationGraph';
 import { normalizePlotData } from '../../functions/normalize';
-import { formatToAgency } from '../../functions/format';
+import { extractNumbers, formatToAgency } from '../../functions/format';
 
-export default function SummaryPage({ dataList, summary }) {
+function orderStringsWithNum(string1: string, string2: string) {
+  const num1 = extractNumbers(string1);
+  const num2 = extractNumbers(string2);
+
+  const texto1 = string1.replace(/\d+$/, '');
+  const texto2 = string2.replace(/\d+$/, '');
+
+  if (texto1 < texto2) {
+    return -1;
+  }
+  if (texto1 > texto2) {
+    return 1;
+  }
+
+  return num1 - num2;
+}
+
+export default function SummaryPage({
+  dataList,
+  summary,
+}: {
+  dataList: v2AgencyBasic[];
+  summary: string;
+}) {
   const pageTitle = `${formatToAgency(summary)}`;
   const [value, setValue] = useState('');
   return (
@@ -87,15 +110,7 @@ export default function SummaryPage({ dataList, summary }) {
                 </ListSubheader>
 
                 {dataList
-                  .sort((a, b) => {
-                    if (a.id_orgao < b.id_orgao) {
-                      return -1;
-                    }
-                    if (a.id_orgao > b.id_orgao) {
-                      return 1;
-                    }
-                    return 1;
-                  })
+                  .sort((a, b) => orderStringsWithNum(a.id_orgao, b.id_orgao))
                   .map(ag => (
                     <MenuItem
                       key={ag.id_orgao}

--- a/src/pages/orgao/[agency]/[year]/index.tsx
+++ b/src/pages/orgao/[agency]/[year]/index.tsx
@@ -8,6 +8,7 @@ import Footer from '../../../../components/Essentials/Footer';
 import api from '../../../../services/api';
 import AgencyWithNavigation from '../../../../components/RemunerationBarGraph';
 import { normalizeMonthlyPlotData } from '../../../../functions/normalize';
+import { formatAgency } from '../../../../functions/format';
 
 export default function AgencyPage({
   id,
@@ -33,7 +34,7 @@ export default function AgencyPage({
   function navigateToGivenYear(y: number) {
     router.push(`/orgao/${id}/${y}`);
   }
-  const pageTitle = `${id.toUpperCase()} - ${year}`;
+  const pageTitle = `${formatAgency(id).toUpperCase()} / ${year}`;
 
   useEffect(() => {
     fetchMIData();


### PR DESCRIPTION
Esse PR:
* Remove a ocorrência de "membros ativos" (deixando apenas "membros");
* Formata as siglas dos TRF's e organiza-os de forma a considerar seus números;
* Aplica a função de formatação das siglas também no título da página.