### PR TITLE
Parando de pré-carregar as páginas com muitos órgãos

### DIFF
--- a/src/pages/grupo/[summary].tsx
+++ b/src/pages/grupo/[summary].tsx
@@ -172,8 +172,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
       { params: { summary: 'conselhos-de-justica' } },
     ];
     return {
-      paths,
-      fallback: true,
+      paths: [],
+      fallback: 'blocking',
     };
   } catch (error) {
     return {


### PR DESCRIPTION
A ação abrir alguma página de grupo-de-órgãos não tinha uma fluidez tão bacana. Esse PR para de pré-carregar essas páginas visando uma melhora de desempenho em acessar os dados da api no momento de abertura da página