### PR TITLE
chore: metadata display "Coleta manual" instead of "--" for access info

### DIFF
--- a/src/components/OmaChart/components/HandleMetadata.tsx
+++ b/src/components/OmaChart/components/HandleMetadata.tsx
@@ -72,7 +72,7 @@ export function HandleAccess({ text }: { text: string }) {
           <ListItemIcon>
             <Close color="error" />
           </ListItemIcon>
-          <Typography variant="subtitle2">--</Typography>
+          <Typography variant="subtitle2">Coleta manual</Typography>
         </Box>
       );
   }


### PR DESCRIPTION
Preparando os metadados para a entrada de coletas manuais