### PR TITLE
refactor: remove createdAt prop from TransparencySection

### DIFF
--- a/src/components/IndexPage/TransparencySection.tsx
+++ b/src/components/IndexPage/TransparencySection.tsx
@@ -51,13 +51,11 @@ type TransparencySectionProps = {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   transparencyData: any[];
   formatedEndDate: string;
-  createdAt: Date;
 };
 
 export default function TransparencySection({
   transparencyData,
   formatedEndDate,
-  createdAt,
 }: TransparencySectionProps) {
   const [value, setValue] = useState(0);
 
@@ -96,16 +94,7 @@ export default function TransparencySection({
               </p>
               <p>
                 Este gráfico representa dados de <b>janeiro de 2018</b> até{' '}
-                <b>{formatedEndDate.toLowerCase()}</b> e foi gerado em{' '}
-                <b>
-                  {createdAt.toLocaleDateString('pt-BR', {
-                    calendar: 'gregory',
-                    day: '2-digit',
-                    month: 'long',
-                    year: 'numeric',
-                    timeZone: 'UTC',
-                  })}
-                </b>
+                <b>{formatedEndDate.toLowerCase()}</b>.
               </p>
             </Grid>
           </Grid>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,7 +12,6 @@ import api from '../services/api';
 import MONTHS from '../@types/MONTHS';
 import light from '../styles/theme-light';
 import { getCurrentYear } from '../functions/currentYear';
-import COLLECT_INFOS from '../@types/COLLECT_INFOS';
 import ShareModal from '../components/Common/ShareModal';
 import DownloadDumpDialog from '../components/Common/DownloadDumpDialog';
 import { useDownloadDump } from '../hooks/useDownloadDump';
@@ -49,7 +48,6 @@ export default function Index({
   const [loading, setLoading] = useState(true);
   const [openDialog, setOpenDialog] = useState(false);
   const [modalIsOpen, setModalIsOpen] = useState(false);
-  const [createdAt, setCreatedAt] = useState<Date>(new Date());
   const [fileLink, dumpDate] = useDownloadDump();
   const nextDateIsNavigable = useMemo<boolean>(
     () => year !== new Date().getFullYear(),
@@ -58,15 +56,6 @@ export default function Index({
   const previousDateIsNavigable = useMemo<boolean>(() => year !== 2018, [year]);
   useEffect(() => {
     fetchGeneralChartData();
-    const date = new Date(
-      getCurrentYear(),
-      new Date().getDate() <= COLLECT_INFOS.COLLECT_DATE
-        ? new Date().getMonth() - 1
-        : new Date().getMonth(),
-      17,
-    );
-
-    setCreatedAt(date);
   }, [year]);
 
   async function fetchGeneralChartData() {
@@ -128,7 +117,6 @@ export default function Index({
         <Paper elevation={0} square>
           <Container>
             <IndexPage.TransparencySection
-              createdAt={createdAt}
               formatedEndDate={formatedEndDate}
               transparencyData={transparencyData}
             />


### PR DESCRIPTION
### Removendo data de geração do gráfico de transparência, já que ele é gerado automaticamente quando há mudança nos dados
<img src="https://github.com/user-attachments/assets/fcdb4925-33fc-4b50-8ca6-1ba50c2b858a" width="350px" />
<img src="https://github.com/user-attachments/assets/bc8892ff-14f5-43f8-a10b-7fb925fd1e79" width="350px" />

