### PR TITLE
fix: update color handling for 'Sem Dados' series

### DIFF
--- a/src/components/RemunerationBarGraph/components/MoneyHeadingsChart.tsx
+++ b/src/components/RemunerationBarGraph/components/MoneyHeadingsChart.tsx
@@ -81,11 +81,13 @@ const MoneyHeadingsChart = ({
   width?: number | string;
   height?: number | string;
 }) => {
-  // data has to be fixed to ensure all months are present before passing to rub()
+  // `data` has to be fixed to ensure all months are present before passing to rub()
   // This is important to ensure that the chart is always filled with 12 months
   const fixedData = fixData(data);
   const rubs = rub(fixedData);
   const colors = useUniqueColors(rubs.length);
+  // Add a color for 'Sem Dados' series
+  colors.push('#2C3236');
 
   const MaxMonthPlaceholder = Math.max(
     ...rubs.map(r => r.data).reduce((a, b) => a.concat(b), []),
@@ -305,7 +307,6 @@ const MoneyHeadingsChart = ({
                 type: 'bar',
                 name: 'Sem Dados',
                 data: monthsWithoutData,
-                color: '#2C3236',
               },
             ]}
             width={width}


### PR DESCRIPTION
Resolvendo problemas de cores ao mudar o ano selecionado do gráfico de gasto mensal em benefícios

Antes (cor da barra de `sem dados` invadindo a stack de rubricas):

https://github.com/user-attachments/assets/41347352-f18e-4283-accd-2e163ab75227

Depois:

https://github.com/user-attachments/assets/ab2b9a01-52fb-46a4-b7a8-a40a5c33d86d

