### PR TITLE
refactor: optimize data handling in Money Headings Charts

### DIFF
--- a/src/components/AnnualRemunerationGraph/functions/index.ts
+++ b/src/components/AnnualRemunerationGraph/functions/index.ts
@@ -93,46 +93,25 @@ export const noData = ({
   data,
   baseRemunerationDataTypes,
   otherRemunerationsDataTypes,
-  type,
 }: {
   data: AnnualSummaryData[];
   baseRemunerationDataTypes?: string;
   otherRemunerationsDataTypes?: string;
-  type?: 'rubrica';
 }): number[] => {
   const noDataArr: number[] = [];
   const currentYear = getCurrentYear();
 
-  if (type === 'rubrica') {
-    for (let i = 2018; i <= currentYear; i += 1) {
-      if (yearsWithData(data)?.includes(i)) {
-        noDataArr.push(0);
-      } else if (!yearsWithData(data)?.includes(i)) {
-        noDataArr.push(
-          data
-            .map(d => d.resumo_rubricas.outras)
-            .reduce((a, b) => {
-              if (a > b) {
-                return a;
-              }
-              return b;
-            }, 0),
-        );
-      }
-    }
-  } else {
-    for (let i = 2018; i <= currentYear; i += 1) {
-      if (yearsWithData(data)?.includes(i)) {
-        noDataArr.push(0);
-      } else if (!yearsWithData(data)?.includes(i)) {
-        noDataArr.push(
-          MaxMonthPlaceholder({
-            data,
-            baseRemunerationDataTypes,
-            otherRemunerationsDataTypes,
-          }),
-        );
-      }
+  for (let i = 2018; i <= currentYear; i += 1) {
+    if (yearsWithData(data)?.includes(i)) {
+      noDataArr.push(0);
+    } else if (!yearsWithData(data)?.includes(i)) {
+      noDataArr.push(
+        MaxMonthPlaceholder({
+          data,
+          baseRemunerationDataTypes,
+          otherRemunerationsDataTypes,
+        }) || null,
+      );
     }
   }
 
@@ -193,27 +172,15 @@ export const fillNoDataIndexes = (
 export const createDataArray = ({
   tipoRemuneracao,
   data,
-  type,
 }: {
   tipoRemuneracao: keyof ItemSummary;
   data: AnnualSummaryData[];
-  type?: 'rubrica';
 }): number[] => {
   let incomingData = [];
 
-  if (type === 'rubrica') {
-    incomingData = data
-      ?.sort((a, b) => a.ano - b.ano)
-      .map(d =>
-        d.resumo_rubricas[tipoRemuneracao] === undefined
-          ? 0
-          : d.resumo_rubricas[tipoRemuneracao],
-      );
-  } else {
-    incomingData = data
-      ?.sort((a, b) => a.ano - b.ano)
-      .map(d => (d[tipoRemuneracao] === undefined ? 0 : d[tipoRemuneracao]));
-  }
+  incomingData = data
+    ?.sort((a, b) => a.ano - b.ano)
+    .map(d => (d[tipoRemuneracao] === undefined ? 0 : d[tipoRemuneracao]));
 
   const dataArray = fillNoDataIndexes(data, incomingData);
 


### PR DESCRIPTION
Esse PR:
* Remove da lista as rubricas que não tiveram valor maior do que 0 em nenhum ano ou mês
* Refatora a lógica de criação da barra cinza escuro (sem dados) que ainda se baseava na rubrica "outras"

Antes (lista de rubricas gigantesca, barra cinza escuro (sem dados) não aparecendo pq todas as rubricas desse órgão foram desambiguadas):
![Captura de Tela 2025-05-14 às 09 51 56](https://github.com/user-attachments/assets/f37dfbc3-16b3-45d2-a6e0-77b43cd52347)

Depois (apenas rubricas com valores maior do que 0 em pelo menos um ano, barra cinza escuro (sem dados) aparecendo corretamente):
![Captura de Tela 2025-05-14 às 09 54 00](https://github.com/user-attachments/assets/28b9628d-3381-403b-b4c4-87bc300ee53a)
